### PR TITLE
Needed a dep on jenkins.war itself for use from hpi:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-war</artifactId>
+        <version>${jenkins.version}</version>
+        <type>war</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness</artifactId>
         <version>${jenkins-test-harness.version}</version>
       </dependency>


### PR DESCRIPTION
Yes, I know you had this originally @andresrc but I confused this with the test dep on `war-for-test`, which is what you need to run functional tests. (Prior to the `jenkins-test-harness` split, that dependency was not present in the plugin POM because it was inherited from the test harness. Now we need to declare the `war-for-test` dependency explicitly so as to override the 1.580.1 version.)

@reviewbybees