### PR TITLE
Skip FindBugs only when skipTests=true, not when skipTests=false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -770,6 +770,7 @@
       <activation>
         <property>
           <name>skipTests</name>
+          <value>true</value>
         </property>
       </activation>
       <properties>


### PR DESCRIPTION
NetBeans can be configured to pass `-DskipTests=true` to many Maven runs to save time. You can override it on a particular run by changing the value to `false`, but it is harder to avoid setting the property at all. Anything gated by this property should actually check the value.

@reviewbybees esp. @andresrc