### PR TITLE
Move jacoco-m-p in an activeByDefault profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,29 +714,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <excludes>
-            <exclude>**/Messages.class</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -874,6 +851,39 @@
       <properties>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
       </properties>
+    </profile>
+    <profile>
+      <id>enable-jacoco</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <excludes>
+                <exclude>**/Messages.class</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>node-classifier-linux</id>


### PR DESCRIPTION
Can be useful to be able to simply globally disable jacoco using

    mvn '-P!enable-jacoco' blah

Use case: the default configuration for all our SonarQube projects analysis is :
`mvn clean org.jacoco:jacoco-maven-plugin:0.7.4.201502262128:prepare-agent verify ${globalMavenProfileSocle} --batch-mode -V -U`

But that crashes with a `StackOverflowError` since this makes running two agents in different versions, like apparently the same issue explained in https://github.com/jacoco/jacoco/issues/112