### PR TITLE
Fix 1.580 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1142,7 +1142,7 @@
     <profile>
       <id>jenkins-580</id>
       <properties>
-        <jenkins.version>1.580.4</jenkins.version>
+        <jenkins.version>1.580.3</jenkins.version>
         <hpi-plugin.version>1.106</hpi-plugin.version>
         <stapler-plugin.version>1.17</stapler-plugin.version>
         <java.level>6</java.level>


### PR DESCRIPTION
1.580.3 was the last release of 1.580.x

Noticed this when testing builds after switching to the plugin pom - the 1.580 profile always failed to download Jenkins 1.580.4