### PR TITLE
Modify default npm install log level to silence download mess in logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <slf4jVersion>1.7.7</slf4jVersion>
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
-    <npm.loglevel /> <!-- may use e.g. -\-silent (without backslash) -->
+    <npm.loglevel>--loglevel warn</npm.loglevel> <!-- may use e.g. -\-silent (without backslash) -->
   </properties>
 
   <prerequisites>


### PR DESCRIPTION
npm install is dumping way too much download status to the logs.