### PR TITLE
Use maven-hpi-plugin 1.117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <arguments> </arguments>
     <jenkins.version>1.625.3</jenkins.version>
     <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
-    <hpi-plugin.version>1.115</hpi-plugin.version>
+    <hpi-plugin.version>1.117</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/maven-hpi-plugin/pull/28 (see note in [JENKINS-25019](https://issues.jenkins-ci.org/browse/JENKINS-25019) regarding plugins with old core deps—you will see a stack trace) and https://github.com/jenkinsci/maven-hpi-plugin/pull/29.

@reviewbybees esp. @andresrc, @kohsuke