### PR TITLE
Switch to Servlet API 3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
         <version>3.1.0</version>
       </dependency>
       <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>2.4</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-annotations</artifactId>
         <version>1.14</version>
@@ -187,6 +192,11 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -484,8 +494,6 @@
                     <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
                     <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
-                    <!-- From the container, not our code: -->
-                    <exclude>javax.servlet:javax.servlet-api</exclude>
                   </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:
                   <plugin>
@@ -572,8 +580,8 @@
         </executions>
         <configuration>
           <signature>
-              <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java1${java.level}</artifactId>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java1${java.level}</artifactId>
           </signature>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,10 @@
         <artifactId>junit</artifactId>
         <version>4.12</version>
       </dependency>
-      <dependency>
+      <dependency> <!-- from org.eclipse.jetty:jetty-server:9.2.15.v20160210 -->
         <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.4</version>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>3.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.mojo</groupId>
@@ -186,7 +186,7 @@
     <!-- dependencies provided by virtue of running in Jenkins -->
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
+      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -484,6 +484,8 @@
                     <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
                     <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
+                    <!-- From the container, not our code: -->
+                    <exclude>javax.servlet:javax.servlet-api</exclude>
                   </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:
                   <plugin>
@@ -570,8 +572,8 @@
         </executions>
         <configuration>
           <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
+              <groupId>org.codehaus.mojo.signature</groupId>
+              <artifactId>java1${java.level}</artifactId>
           </signature>
         </configuration>
       </plugin>


### PR DESCRIPTION
A test error in https://github.com/jenkinsci/maven-plugin/pull/60 led me to the realization that as of https://github.com/jenkinsci/jenkins-test-harness/pull/12 we are running tests with a version of Jetty which requires Servlet 3.1, and so we must also have that in our test classpath; else you can get errors like

```
java.lang.NoSuchMethodError: javax.servlet.http.HttpServletResponse.getStatus()I
	at org.eclipse.jetty.server.handler.ErrorHandler.handle(ErrorHandler.java:112)
	at org.eclipse.jetty.server.Response.sendError(Response.java:597)
	at org.eclipse.jetty.server.Response.sendError(Response.java:544)
	at javax.servlet.http.HttpServletResponseWrapper.sendError(HttpServletResponseWrapper.java:117)
	at javax.servlet.http.HttpServletResponseWrapper.sendError(HttpServletResponseWrapper.java:117)
	at hudson.model.DirectoryBrowserSupport.serveFile(DirectoryBrowserSupport.java:280)
	at …
```

My first thought was to keep 2.4 in the `provided` classpath but add 3.1 to the `test` classpath—possible since the `artifactId` changed as of 3.0. Yet this does not work; Maven seems to include the 2.4 version first and so you still get the error.

So I just replaced the Servlet API version. But this leads to the problem that a plugin could accidentally start using 3.0+ (or even 2.5+) APIs, and thus not work on older Jenkins releases. My next thought was to use Animal Sniffer to solve this, but after some effort I was not able to get it to work: https://github.com/mojohaus/animal-sniffer/issues/19

So for now I am keeping it simple, and you just have to read the Servlet API Javadoc if in doubt. Note that `hpi:run` also uses the new Jetty as of https://github.com/jenkinsci/maven-hpi-plugin/pull/28 so this will not catch problems either.

@reviewbybees esp. @kohsuke, @andresrc