### PR TITLE
[SUREFIRE-1138] Make concurrency work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.18.1</version>
+          <version>2.19.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
[SUREFIRE-1138](https://issues.apache.org/jira/browse/SUREFIRE-1138)

We use `forkCount` (by default `1C`) and `reuseForks=true`; apparently this combination got broken in 2.18 and fixed in 2.19. I had noticed that my `~/.m2/settings.xml` entry

```xml
<profile>
    <id>faster</id>
    <activation>
        <activeByDefault>true</activeByDefault>
    </activation>
    <properties>
        <concurrency>2C</concurrency>
    </properties>
</profile>
```

was not working.

@reviewbybees esp. @andresrc