### PR TITLE
Support plugins using Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
         <version>1.0</version>
         <type>signature</type>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo.signature</groupId>
+        <artifactId>java18</artifactId>
+        <version>1.0</version>
+        <type>signature</type>
+      </dependency>
       <!-- mark logging dependencies as provided by war -->
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
Uses https://github.com/mojohaus/animal-sniffer/issues/1 to allow you to declare `java.level=8`.

@reviewbybees