### PR TITLE
Switch to java.awt.headless in Surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -687,6 +687,7 @@
           </systemProperties>
           <reuseForks>true</reuseForks>
           <forkCount>${concurrency}</forkCount>
+          <argLine>-Djava.awt.headless=true ${argLine}</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
On OS X, ForkedBooter steals window focus, so you need to get "-Djava.awt.headless=true" on the Surefire command line to make that stop. See https://somethingididnotknow.wordpress.com/2014/07/23/forkedbooter-steals-window-focus-on-mac-os-while-maven-is-running/.

cc @reviewbybees