### PR TITLE
Fix the bug introduced in projects relying on gulp build before compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1091,7 +1091,7 @@
               </execution>
 
               <execution>
-                <phase>compile</phase>
+                <phase>generate-sources</phase>
                 <id>gulp bundle</id>
                 <goals>
                   <goal>gulp</goal>


### PR DESCRIPTION
This was mentioned here and never corrected: 
https://github.com/jenkinsci/plugin-pom/pull/20#discussion_r62693794

It breaks pipeline stage view builds if not corrected (with any version after plugin-pom 2.6).  Except when using hpi:run, of course.

@reviewbybees 