### PR TITLE
Add nodejs for 32 bit linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -947,6 +947,19 @@
       </properties>
     </profile>
     <profile>
+      <id>node-classifier-linux-x86</id>
+      <activation>
+        <os>
+          <family>Linux</family>
+          <arch>i386</arch>
+        </os>
+      </activation>
+      <properties>
+        <node.download.file>node-v${node.version}-linux-x86.tar.gz</node.download.file>
+        <node.download.classifier />
+      </properties>
+    </profile>
+    <profile>
       <id>node-classifier-mac</id>
       <activation>
         <os>


### PR DESCRIPTION
Hi,

I've encountered a problem while installing blueocean-plugin on my 32bit Debian 9 server.
You can find the full post in the [Jenkins Dev Google Group](https://groups.google.com/forum/#!topic/jenkinsci-dev/lRTz19Yv1YY).

I've solved my problem by adding the following xml to `~/.m2/repository/org/jenkins-ci/plugins/plugin/2.10/plugin-2.10.pom` :

```xml
<profile>
  <id>node-classifier-linux-i386</id>
  <activation>
    <os>
      <family>Linux</family>
      <arch>i386</arch>
    </os>
  </activation>
  <properties>
    <node.download.file>node-v${node.version}-linux-x86.tar.gz</node.download.file>
    <node.download.classifier />
  </properties>
</profile>
```

And it's also the content of my PR (I just replaced i386 in the id by 32 bits to match the convention), because it will help if it could be integrated to the sources :D 

I don't know what is your politic when it comes to support some old or exotic architecture, but it might be interesting to look at ARM architecture also.

I've also found a similar file in the [jenkins main repository](https://github.com/jenkinsci/jenkins/blob/master/war/pom.xml). Should I also open a pull request ?