### PR TITLE
suppress missing org.eclipse.m2e:lifecycle-mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,50 +431,6 @@
           <artifactId>maven-license-plugin</artifactId>
           <version>1.7</version>
         </plugin>
-        <!--
-            This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.
-            the plugins mention here are the ones we do not have direct control over, but are used for a jenkins plugin - all other
-            will be changed to in there source to support eclipse soon (hpi, license, localizer, access-modifier).
-            see also: http://wiki.eclipse.org/M2E_compatible_maven_plugins
-        -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <versionRange>[1.0,)</versionRange>
-                    <goals>
-                      <goal>display-info</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.codehaus.gmaven</groupId>
-                    <artifactId>gmaven-plugin</artifactId>
-                    <versionRange>[1.0,)</versionRange>
-                    <goals>
-                      <goal>testCompile</goal>
-                      <goal>generateTestStubs</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -803,6 +759,64 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+        <id>only-eclipse</id>
+        <activation>
+          <property>
+            <name>m2e.version</name>
+          </property>
+        </activation>
+        <build>
+            <pluginManagement>
+                <plugins>
+                <!--
+                    This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.
+                    the plugins mention here are the ones we do not have direct control over, but are used for a jenkins plugin - all other
+                    will be changed to in there source to support eclipse soon (hpi, license, localizer, access-modifier).
+                    see also: http://wiki.eclipse.org/M2E_compatible_maven_plugins
+                -->
+                <plugin>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <version>1.0.0</version>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <versionRange>[1.0,)</versionRange>
+                            <goals>
+                              <goal>display-info</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore />
+                          </action>
+                        </pluginExecution>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.codehaus.gmaven</groupId>
+                            <artifactId>gmaven-plugin</artifactId>
+                            <versionRange>[1.0,)</versionRange>
+                            <goals>
+                              <goal>testCompile</goal>
+                              <goal>generateTestStubs</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore />
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
+                </plugin>
+                </plugins>
+            </pluginManagement>
+        </build>
     </profile>
     <profile>
       <id>always-check-remote-repositories</id>


### PR DESCRIPTION
This PR moves the lifecycle-mapping plugin to the profiles section, so it gets only activated in an eclipse environment.
Discussion thread: https://stackoverflow.com/questions/7905501/get-rid-of-pom-not-found-warning-for-org-eclipse-m2elifecycle-mapping

Log output (before):
```
11:53:22 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/eclipse/m2e/lifecycle-mapping/1.0.0/lifecycle-mapping-1.0.0.pom
11:53:22 [WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
11:53:22 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/eclipse/m2e/lifecycle-mapping/1.0.0/lifecycle-mapping-1.0.0.jar
11:53:22 [WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Could not find artifact org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 in repo.jenkins-ci.org (http://repo.jenkins-ci.org/public/)
11:53:22 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/codehaus/mojo/maven-metadata.xml
11:53:22 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/jenkins-ci/tools/maven-metadata.xml
11:53:22 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/apache/maven/plugins/maven-metadata.xml
11:53:23 [INFO] Downloaded: http://repo.jenkins-ci.org/public/org/apache/maven/plugins/maven-metadata.xml (10 KB at 21.3 KB/sec)
11:53:23 [INFO] Downloaded: http://repo.jenkins-ci.org/public/org/jenkins-ci/tools/maven-metadata.xml (385 B at 0.8 KB/sec)
11:53:23 [INFO] Downloaded: http://repo.jenkins-ci.org/public/org/codehaus/mojo/maven-metadata.xml (20 KB at 31.5 KB/sec)
11:53:23 [INFO] Downloading: http://repo.jenkins-ci.org/public/org/apache/maven/plugins/maven-checkstyle-plugin/maven-metadata.xml
11:53:23 [INFO] Downloaded: http://repo.jenkins-ci.org/public/org/apache/maven/plugins/maven-checkstyle-plugin/maven-metadata.xml (2 KB at 3.1 KB/sec)
11:53:23 [INFO]                                                                         
11:53:23 [INFO] ------------------------------------------------------------------------
11:53:23 [INFO] Building Performance Signature with Dynatrace 2.1.2-SNAPSHOT
11:53:23 [INFO] ------------------------------------------------------------------------
11:53:23 [WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
11:53:23 [WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Failure to find org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 in http://repo.jenkins-ci.org/public/ was cached in the local repository, resolution will not be reattempted until the update interval of repo.jenkins-ci.org has elapsed or updates are forced
```