### PR TITLE
Set trimStackTrace=false to work around SUREFIRE-1226

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
     <concurrency>1C</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
+    <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
     <!-- Whether the build should fail if findbugs finds any error. -->
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
     <findbugs.failOnError>true</findbugs.failOnError>


### PR DESCRIPTION
Works around [SUREFIRE-1226](https://issues.apache.org/jira/browse/SUREFIRE-1226). Unfortunately means that stack frames we _did_ want trimmed are now shown, but that is the lesser evil.

@reviewbybees