### PR TITLE
Simplify node build execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -611,7 +611,11 @@
         <executions>
           <execution>
             <goals>
-              <goal>javadoc</goal>
+              <!--
+                Goal needs to be the "-no-fork" variant, otherwise it causes other plugins running
+                in e.g. the "initialise" phase to execute twice (e.g. the enforcer plugin + frontend node/npm install).
+              -->
+              <goal>javadoc-no-fork</goal>
             </goals>
             <!-- As soon as possible but after required generate-sources phase -->
             <phase>process-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -1127,25 +1127,25 @@
 
               <execution>
                 <phase>generate-sources</phase>
-                <id>npm build</id>
+                <id>npm mvnbuild</id>
                 <goals>
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <!-- The package.json must define a "build" script -->
-                  <arguments>run build</arguments>
+                  <!-- The package.json must define an "mvnbuild" script -->
+                  <arguments>run mvnbuild</arguments>
                 </configuration>
               </execution>
 
               <execution>
                 <phase>test</phase>
-                <id>npm test</id>
+                <id>npm mvntest</id>
                 <goals>
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <!-- The package.json must define a "test" script -->
-                  <arguments>run test</arguments>
+                  <!-- The package.json must define an "mvntest" script -->
+                  <arguments>run mvntest</arguments>
                 </configuration>
               </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1061,10 +1061,10 @@
       </build>
     </profile>
     <profile>
-      <id>gulp-execution</id>
+      <id>node-execution</id>
       <activation>
         <file>
-          <exists>gulpfile.js</exists>
+          <exists>.mvn_exec_node</exists>
         </file>
       </activation>
       <build>
@@ -1123,23 +1123,25 @@
 
               <execution>
                 <phase>generate-sources</phase>
-                <id>gulp bundle</id>
+                <id>npm build</id>
                 <goals>
-                  <goal>gulp</goal>
+                  <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>bundle</arguments>
+                  <!-- The package.json must define a "build" script -->
+                  <arguments>run build</arguments>
                 </configuration>
               </execution>
 
               <execution>
                 <phase>test</phase>
-                <id>gulp test</id>
+                <id>npm test</id>
                 <goals>
-                  <goal>gulp</goal>
+                  <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>test lint ${skip.node.tests} ${skip.node.lint} --skipBundle</arguments>
+                  <!-- The package.json must define a "test" script -->
+                  <arguments>run test</arguments>
                 </configuration>
               </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,13 @@
     <release.skipTests>true</release.skipTests>
     <!-- same version as in org.jenkins-ci.main:pom -->
     <!-- TODO see if we can remove this properties -->
+    <!--
+      Change to "javadoc-no-fork" locally if the plugin build is running some plugins twice. This has
+      been seen with some plugins configured to execute in the the "initialise" phase (e.g. the enforcer plugin + frontend node/npm install).
+      Note however that "javadoc-no-fork" has been known to have memory leak issues, so beware.
+    -->
+    <javadoc.exec.goal>javadoc</javadoc.exec.goal>
+
     <slf4jVersion>1.7.7</slf4jVersion>
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
@@ -611,11 +618,7 @@
         <executions>
           <execution>
             <goals>
-              <!--
-                Goal needs to be the "-no-fork" variant, otherwise it causes other plugins running
-                in e.g. the "initialise" phase to execute twice (e.g. the enforcer plugin + frontend node/npm install).
-              -->
-              <goal>javadoc-no-fork</goal>
+              <goal>${javadoc.exec.goal}</goal>
             </goals>
             <!-- As soon as possible but after required generate-sources phase -->
             <phase>process-sources</phase>


### PR DESCRIPTION
Also makes it more flexible by allowing the project to define what needs to happen for build and test + does not assume specific tools such as gulp etc.

So the profiles are now enabled via the presence of a simple marker file named `.mvn_exec_node`, Vs tying it to the existence of a framework specific file i.e. `gulpfile.js` (purposely not assuming they should be enabled via `package.json`). It does add the requirement that the project needs to define 2 [scripts](https://docs.npmjs.com/misc/scripts) in the `package.json` (named "mvnbuild" and "mvntest") that the profiles now execute (Vs executing gulp tasks).

@jenkinsci/code-reviewers @reviewbybees 