### PR TITLE
jitpack.io support: attach sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1232,5 +1232,28 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <activation>
+        <property>
+          <name>env.JITPACK</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
[Docs](https://jitpack.io/docs/BUILDING/#build-environment) for @jitpack build environment

Can be used prior to merge by including in your plugin POM:

```xml
    <parent>
        <groupId>com.github.jglick</groupId>
        <artifactId>plugin-pom</artifactId>
        <version>f831bd8</version>
        <relativePath/>
    </parent>
    <groupId>org.jenkins-ci.plugins</groupId>
<!-- … -->
        <repository>
            <id>jitpack.io</id>
            <url>https://jitpack.io</url>
        </repository>
```

And if you defined a general mirror in your `~/.m2/settings.xml`:

```xml
<mirrorOf>*,!jitpack.io</mirrorOf>
```

It does work: when you have a pair of plugins with snapshot dependencies, you can use this PR (or, if merged & released, just a sufficiently new parent) on the upstream plugin; then in the downstream plugin, before committing and pushing, you add

```xml
        <repository>
            <id>jitpack.io</id>
            <url>https://jitpack.io</url>
        </repository>
```

and replace

```xml
        <dependency>
            <groupId>org.jenkins-ci.plugins</groupId>
            <artifactId>upstream</artifactId>
            <version>1.5-SNAPSHOT</version>
        </dependency>
```

with

```xml
        <dependency>
            <groupId>com.github.YOURNAME</groupId> <!-- acct. with your fork -->
            <artifactId>upstream-plugin</artifactId>
            <version>abc1234</version> <!-- tip of your PR branch -->
        </dependency>
```

Once the upstream change has been released, you would need to remember to revert these changes, along with picking up the release version of course.

But builds are rather slow (since they do not cache Maven downloads), and sometimes downloads or even the online logs just hang for a long time, so I am not sure whether it is really practical: you have to wait 5-10m before you can locally build the downstream plugin at that commit.

Also the `branch-SNAPSHOT` system does not seem to work reliably, or at least I got weird effects, and it rebuilt commits unnecessarily. If I could get this to work, it would make sense to integrate with https://github.com/jenkinsci/maven-hpi-plugin/pull/25.

At any rate, for certain purposes it could be useful.

@reviewbybees