### PR TITLE
Preconfigure test-jar executions to exclude useless stuff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
     <findbugs.failOnError>true</findbugs.failOnError>
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
+    <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
+    <no-test-jar>true</no-test-jar>
     <!-- same version as in org.jenkins-ci.main:pom -->
     <!-- TODO see if we can remove this properties -->
     <!--
@@ -312,6 +314,7 @@
           <version>2.6</version>
           <configuration>
             <excludes>the.hpl,InjectedTest.class,test-dependencies/</excludes>
+            <skip>${no-test-jar}</skip>
           </configuration>
         </plugin>
         <plugin>
@@ -448,6 +451,17 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jar</goal>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
@@ -755,8 +769,16 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar</goal>
-                  <goal>test-jar</goal> <!-- TODO ideally would be skipped unless we have a test-jar execution of maven-jar-plugin -->
                 </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <goals>
+                  <goal>test-jar</goal>
+                </goals>
+                <configuration>
+                  <skipSource>${no-test-jar}</skipSource>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -1256,8 +1278,16 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar</goal>
-                  <goal>test-jar</goal> <!-- TODO as above -->
                 </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <goals>
+                  <goal>test-jar</goal>
+                </goals>
+                <configuration>
+                  <skipSource>${no-test-jar}</skipSource>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,11 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.6</version>
           <configuration>
-            <excludes>the.hpl,InjectedTest.class,test-dependencies/</excludes>
+            <excludes>
+              <exclude>the.hpl</exclude>
+              <exclude>InjectedTest.class</exclude>
+              <exclude>test-dependencies/</exclude>
+            </excludes>
             <skip>${no-test-jar}</skip>
           </configuration>
         </plugin>
@@ -357,7 +361,9 @@
           <artifactId>maven-source-plugin</artifactId>
           <version>2.4</version>
           <configuration>
-            <excludes>InjectedTest.java</excludes>
+            <excludes>
+              <exclude>InjectedTest.java</exclude>
+            </excludes>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
               <exclude>InjectedTest.class</exclude>
               <exclude>test-dependencies/</exclude>
             </excludes>
-            <skip>${no-test-jar}</skip>
+            <skip>${no-test-jar}</skip> <!-- see below -->
           </configuration>
         </plugin>
         <plugin>
@@ -462,7 +462,7 @@
         <executions>
           <execution>
             <goals>
-              <goal>jar</goal>
+              <goal>jar</goal> <!-- note that if jar:jar gets a skip parameter in the future then this would need to be moved to a separate execution -->
               <goal>test-jar</goal>
             </goals>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,9 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.6</version>
+          <configuration>
+            <excludes>the.hpl,InjectedTest.class,test-dependencies/</excludes>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -350,6 +353,9 @@
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
           <version>2.4</version>
+          <configuration>
+            <excludes>InjectedTest.java</excludes>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-war-plugin</artifactId>
@@ -749,6 +755,7 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar</goal>
+                  <goal>test-jar</goal> <!-- TODO ideally would be skipped unless we have a test-jar execution of maven-jar-plugin -->
                 </goals>
               </execution>
             </executions>
@@ -1233,6 +1240,7 @@
       </build>
     </profile>
     <profile>
+      <id>jitpack</id>
       <activation>
         <property>
           <name>env.JITPACK</name>
@@ -1248,6 +1256,7 @@
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar</goal>
+                  <goal>test-jar</goal> <!-- TODO as above -->
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
I noticed that uploading `*-tests.jar` to the repository was taking forever, and realized that the vast bulk of the upload size for one of these plugin releases was actually in `*-tests.jar!/test-dependencies/*.hpi`, which is never used. Fixed some other junk while I was here.

@reviewbybees
