### PR TITLE
test-jar fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # plugin-pom
 Parent POM for Jenkins Plugins
 
+## Introduction
+
 This new parent POM is decoupled from the core Jenkins project, both from the Maven and repository perspectives.
 
 The main changes are:
@@ -21,6 +23,8 @@ thought to be overridden are no longer based on properties. The main remaining o
 
 Being able to specify the `jenkins.version` simplifies testing the plugin with different core versions, which is
 important, among others, for the Plugin Compatibility Testing.
+
+## Usage
 
 In order to use the new POM:
 * Change the parent POM of your plugin:
@@ -44,6 +48,8 @@ If you had a `jar:test-jar` execution, delete it and add to `properties`:
 ```xml
 <no-test-jar>false</no-test-jar>
 ```
+
+## Baselines
 
 It is handy to be able to select different Jenkins baselines with a Maven profile.
 To set this up, you must edit your `~/.m2/settings.xml` to include some new entries in the `<profiles>` section.
@@ -142,3 +148,7 @@ there is no need to edit your POM. Just run:
 or
 
     mvn -Pjenkins-651 hpi:run
+
+## For maintainers
+
+Before releasing changes, try the [integration test instructions for the `maven-hpi-plugin`](https://github.com/jenkinsci/maven-hpi-plugin/blob/master/README.md).

--- a/pom.xml
+++ b/pom.xml
@@ -312,14 +312,6 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.6</version>
-          <configuration>
-            <excludes>
-              <exclude>the.hpl</exclude>
-              <exclude>InjectedTest.class</exclude>
-              <exclude>test-dependencies/</exclude>
-            </excludes>
-            <skip>${no-test-jar}</skip> <!-- see below -->
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
@@ -461,10 +453,18 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <id>maybe-test-jar</id>
             <goals>
-              <goal>jar</goal> <!-- note that if jar:jar gets a skip parameter in the future then this would need to be moved to a separate execution -->
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>the.hpl</exclude>
+                <exclude>InjectedTest.class</exclude>
+                <exclude>test-dependencies/</exclude>
+              </excludes>
+              <skip>${no-test-jar}</skip>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
#38 was broken: while the correct artifacts were produced inside `target/`, and functional tests would pass, `install:install` would copy `target/$p.jar` rather than `target/$p.hpi` to `~/.m2/repository/…/$p-$v.hpi`, allowing a malformed archive to be uploaded by `deploy` and all hell to break loose. I am not exactly sure what caused this; perhaps something funky in the `maven-hpi-plugin` lifecycle definition, perhaps just a misunderstanding of Maven phase/goal/execution semantics.

@reviewbybees esp. @stephenc (feel free to say “I told you so”)

After merge & release:

- [ ] file amendment to https://github.com/jenkinsci/workflow-step-api-plugin/pull/11
- [ ] file amendment to https://github.com/jenkinsci/cloudbees-folder-plugin/issues/75
- [ ] file amendment to https://github.com/jenkinsci/git-plugin/issues/445
- [ ] file amendment to https://github.com/jenkinsci/mercurial-plugin/issues/89
- [ ] file amendment to https://github.com/jenkinsci/workflow-cps-plugin/issues/88
- [ ] file amendment to https://github.com/jenkinsci/workflow-multibranch-plugin/issues/39
- [ ] file amendment to https://github.com/jenkinsci/workflow-scm-step-plugin/issues/10
- [ ] amend https://github.com/jenkinsci/gerrit-trigger-plugin/issues/300
- [ ] amend https://github.com/jenkinsci/rubymetrics-plugin/issues/31
- [ ] amend https://github.com/jenkinsci/subversion-plugin/issues/175
- [ ] amend https://github.com/jenkinsci/workflow-job-plugin/issues/32
- [ ] amend https://github.com/jenkinsci/workflow-support-plugin/issues/25

Also:

- [ ] start a changelog in this repository
- [ ] and one in `maven-hpi-plugin`
- [ ] and one in `jenkins-test-harness` while we are at it