### PR TITLE
Default to non verbose javadoc generation logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ thought to be overridden are no longer based on properties. The main remaining o
   * In order to make their versions the same as the used core version, `slf4jVersion`, `node.version` and `npm.version`
   properties are provided.
 * Tests are skipped during the `perform` phase of a release (can be overridden by setting `release.skipTests` to false).
+* Javadoc has been set to _quiet_ by default in 2.20+, which means it will only log errors and warnings. 
+  If you really want it verbose, set `quiet` property to `false` for the plugin.
 * General clean up.
 
 Being able to specify the `jenkins.version` simplifies testing the plugin with different core versions, which is

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,9 @@
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.1</version>
+          <configuration>
+            <quiet>true</quiet>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
@reviewbybees 
That change switches the javadoc plugin to quiet mode
(https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#quiet)

This means it will only output errors & warnings, and will stop showing
hundreds of lines, one per file basically, for successful ones.
This is an issue for non trivially small plugins because this will somehow
hide real errors in a sea of success/happy path logs.

I still introduced a property for people who would like to keep that behaviour...