### PR TITLE
[JENKINS-37177] surefire concurrency inappropriate default causes random build failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
-    <concurrency>1C</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
+    <concurrency>1</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
     <!-- Whether the build should fail if findbugs finds any error. -->
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->


### PR DESCRIPTION
As explained in the report, I concur that this setting is not the best one.
We should have a least-surprising default, i.e. one that for instance makes test successful in most cases.
Then, for CI, or for testing, let people choose to go for more hunts.

This settings is even worse nowadays I think, because it is becoming common to slice hosts through containerization, but in most situations people would simply slice the memory and let the default settings on.
That means that you would have more often than some years ago a config with say 4 GB only, but maybe 8 or 16 cores. And that would obviously fail. I had the exact same case in the past with the GWT compiler on that very kind of agent.

In general, hence also on dev boxes like explained in the report, this is also an issue with the Moore Law at least slowing down: we are going to have more and more machines with a bunch of CPUs, but not necessarily more than 16, or even soon 32 GB, which should be enough for running the builds *only* but probably could be short with all the other things developers typically run nowadays (IDEs, all manners of browsers, and so on).

@reviewbybees esp. @jtnord 