### PR TITLE
[JENKINS-41531] compatibleSinceVersion support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <jenkins.version>1.625.3</jenkins.version>
     <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
     <hpi-plugin.version>1.120</hpi-plugin.version>
+    <hpi-plugin.compatibleSinceVersion> </hpi-plugin.compatibleSinceVersion>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
@@ -605,6 +606,7 @@
         <configuration>
           <showDeprecation>true</showDeprecation>
           <contextPath>/jenkins</contextPath>
+          <compatibleSinceVersion>${hpi-plugin.compatibleSinceVersion}</compatibleSinceVersion>
           <!-- TODO specify ${java.level} when JENKINS-20679 implemented -->
         </configuration>
       </plugin>


### PR DESCRIPTION
[JENKINS-41531](https://issues.jenkins-ci.org/browse/JENKINS-41531)

It would be nice if I can specify compatibleSinceVersion in plugin-pom.
compatibleSinceVersion displays texts in the update center warning that new versions of plugins might not be compatible with the installed versions.
https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions

It can be configured as following:
```
  <build>
    <plugins>
      <plugin>
        <groupId>org.jenkins-ci.tools</groupId>
        <artifactId>maven-hpi-plugin</artifactId>
        <extensions>true</extensions>
        <configuration>
          <compatibleSinceVersion>1.0</compatibleSinceVersion>
        </configuration>
      </plugin>
    </plugins>
  </build>
```

This change allows me to configure as following simply:
```
    <properties>
        <hpi-plugin.compatibleSinceVersion>1.0</hpi-plugin.compatibleSinceVersion>
    </properties>
```
