### PR TITLE
Update to maven-hpi-plugin 1.121

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <argLine>-Djava.awt.headless=true</argLine>
     <jenkins.version>1.625.3</jenkins.version>
     <jenkins-test-harness.version>2.15</jenkins-test-harness.version>
-    <hpi-plugin.version>1.120</hpi-plugin.version>
+    <hpi-plugin.version>1.121</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->


### PR DESCRIPTION
Update to maven-hpi-plugin 1.121 to pick up https://github.com/jenkinsci/maven-hpi-plugin/pull/46

It is fixing [JENKINS-40899](https://issues.jenkins-ci.org/browse/JENKINS-40899), needed to run tests and `hpi:run` when working on fixes for more than one plugin using snapshot dependencies between them which are pulled from a Maven snapshots repository.