### PR TITLE
[FIX JENKINS-42008] plugin-pom should embed the sha and branch into the plugins MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,23 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doCheck>false</doCheck>
+          <doUpdate>false</doUpdate>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
@@ -606,6 +623,12 @@
           <showDeprecation>true</showDeprecation>
           <contextPath>/jenkins</contextPath>
           <!-- TODO specify ${java.level} when JENKINS-20679 implemented -->
+          <archive>
+            <manifestEntries combine.children="append">
+              <CommitId>${buildNumber}</CommitId>
+              <Branch>${scmBranch}</Branch>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This change adds 2 lines like the following to the `MANIFEST.MF` of `hpi`s:

```
Branch: master
CommitId: 046af1b646832fdb3f4945ad71b8e30310184b3c
```

@jenkinsci/code-reviewers and @andresrc @stephenc @jglick @jtnord at least