### PR TITLE
Do not use activeByDefault

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -966,7 +966,9 @@
     <profile>
       <id>enable-jacoco</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!disable-jacoco</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -965,11 +965,6 @@
     </profile>
     <profile>
       <id>enable-jacoco</id>
-      <activation>
-        <property>
-          <name>!disable-jacoco</name>
-        </property>
-      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
#11 actually removed the JaCoCo profile by default, as you can see from

    mvn help:active-profiles

Cf. [MNG-4917](https://issues.apache.org/jira/browse/MNG-4917).

@reviewbybees