### PR TITLE
Upgrade download-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
             <executions>
               <execution>
                 <id>get-node</id>


### PR DESCRIPTION
Logs like [this](https://ci.jenkins.io/job/Plugins/job/workflow-cps-plugin/job/PR-110/2/consoleFull) are hard to read in large part because we are missing https://github.com/maven-download-plugin/maven-download-plugin/pull/62.

@reviewbybees