### PR TITLE
[JENKINS-42800] - Bump JaCoCo version to be compatible with Jenkins JaCoCo plugin data format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.2.201409121644</version>
+          <version>0.7.9</version>
         </plugin>
         <plugin>
           <groupId>org.kohsuke.gmaven</groupId>


### PR DESCRIPTION
Issue: https://issues.jenkins-ci.org/browse/JENKINS-42800

Jenkins Jacoco plugin > 2.0.0 (current version is 2.1.0) requires JaCoCo Maven plugin >0.7.5 as indicated on the linked issue and on the plugin page. 

For users which want to stay with old plugin would have to override this change and keep JaCoCo maven plugin < 0.7.5 with Jenkins Jacoco plugin < 2.0.0
See plugin wiki page for more information : https://wiki.jenkins-ci.org/display/JENKINS/JaCoCo+Plugin

@reviewbybees 
