### PR TITLE
Align frontend-version with frontend-m-p prerequisite of 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <slf4jVersion>1.7.7</slf4jVersion>
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
-    <frontend-version>1.3</frontend-version>
+    <frontend-version>1.4</frontend-version>
     <skip.node.tests /> <!-- changed by -DskipTests, if specified - see profile -->
     <skip.node.lint /> <!-- changed by -DskipLint, if specified - see profile -->
     <npm.loglevel /> <!-- may use e.g. -\-silent (without backslash) -->
@@ -87,7 +87,7 @@
   </properties>
 
   <prerequisites>
-    <maven>3.0.4</maven>
+    <maven>3.1.0</maven>
   </prerequisites>
 
   <dependencyManagement>


### PR DESCRIPTION
1.3 was already having a [prerequisite on Maven 3.1.0](https://github.com/eirslett/frontend-maven-plugin/blob/frontend-plugins-1.3/frontend-maven-plugin/pom.xml#L15).

So, updating pom.xml to reflect and bumped the plugin to latest version.

@reviewbybees esp. @tfennelly @scherler @kzantow @michaelneale