### PR TITLE
Pick maven-hpi-plugin 1.122

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <argLine>-Djava.awt.headless=true</argLine>
     <jenkins.version>1.625.3</jenkins.version>
     <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
-    <hpi-plugin.version>1.121</hpi-plugin.version>
+    <hpi-plugin.version>1.122</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->


### PR DESCRIPTION
See https://github.com/jenkinsci/maven-hpi-plugin#1122-2017-apr-12

Personally especially interested in seeing https://github.com/jenkinsci/maven-hpi-plugin/pull/59 propagate for easier diagnosability when running multiple plugin builds in a Pipeline `parallel` step.

@reviewbybees 