### PR TITLE
[JENKINS-43411] add support for yarn-based builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <slf4jVersion>1.7.7</slf4jVersion>
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
+    <yarn.version>0.23.0</yarn.version>
     <frontend-version>1.4</frontend-version>
     <skip.node.tests /> <!-- changed by -DskipTests, if specified - see profile -->
     <skip.node.lint /> <!-- changed by -DskipLint, if specified - see profile -->
@@ -1069,6 +1070,91 @@
                 <id>npm mvntest</id>
                 <goals>
                   <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <!-- The package.json must define an "mvntest" script -->
+                  <arguments>run mvntest</arguments>
+                </configuration>
+              </execution>
+
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>yarn-execution</id>
+      <activation>
+        <file>
+          <exists>.mvn_exec_yarn</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-versions</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>3.1.0</version>
+                    </requireMavenVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>${frontend-version}</version>
+
+            <executions>
+
+              <execution>
+                <phase>initialize</phase>
+                <id>install node and yarn</id>
+                <goals>
+                  <goal>install-node-and-yarn</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>v${node.version}</nodeVersion>
+                  <yarnVersion>v${yarn.version}</yarnVersion>
+                </configuration>
+              </execution>
+
+              <execution>
+                <phase>initialize</phase>
+                <id>yarn install</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+              </execution>
+
+              <execution>
+                <phase>generate-sources</phase>
+                <id>yarn mvnbuild</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <!-- The package.json must define an "mvnbuild" script -->
+                  <arguments>run mvnbuild</arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <phase>test</phase>
+                <id>yarn mvntest</id>
+                <goals>
+                  <goal>yarn</goal>
                 </goals>
                 <configuration>
                   <!-- The package.json must define an "mvntest" script -->

--- a/pom.xml
+++ b/pom.xml
@@ -1136,6 +1136,11 @@
                 <goals>
                   <goal>yarn</goal>
                 </goals>
+                <configuration>
+                  <!-- ensure only one concurrent 'yarn install' -->
+                  <!-- when yarn cache is empty, multiple yarns performing network fetches frequently results in opaque errors -->
+                  <arguments>--mutex network</arguments>
+                </configuration>
               </execution>
 
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -994,115 +994,6 @@
       </build>
     </profile>
     <profile>
-      <id>node-classifier-linux</id>
-      <activation>
-        <os>
-          <family>Linux</family>
-          <arch>amd64</arch>
-        </os>
-      </activation>
-      <properties>
-        <node.download.file>node-v${node.version}-linux-x64.tar.gz</node.download.file>
-        <node.download.classifier />
-      </properties>
-    </profile>
-    <profile>
-      <id>node-classifier-linux-x86</id>
-      <activation>
-        <os>
-          <family>Linux</family>
-          <arch>i386</arch>
-        </os>
-      </activation>
-      <properties>
-        <node.download.file>node-v${node.version}-linux-x86.tar.gz</node.download.file>
-        <node.download.classifier />
-      </properties>
-    </profile>
-    <profile>
-      <id>node-classifier-mac</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <properties>
-        <node.download.file>node-v${node.version}-darwin-x64.tar.gz</node.download.file>
-        <node.download.classifier />
-      </properties>
-    </profile>
-    <profile>
-      <id>node-classifier-windows</id>
-      <activation>
-        <os>
-          <family>windows</family>
-        </os>
-      </activation>
-      <properties>
-        <node.download.file>win-x64/node.exe</node.download.file>
-        <node.download.classifier>/win-x64</node.download.classifier>
-      </properties>
-    </profile>
-    <profile>
-      <id>node-classifier-windows-x86</id>
-      <activation>
-        <os>
-          <family>windows</family>
-          <arch>x86</arch>
-        </os>
-      </activation>
-      <properties>
-        <node.download.file>win-x86/node.exe</node.download.file>
-        <node.download.classifier />
-      </properties>
-    </profile>
-    <profile>
-      <id>node-download</id>
-      <activation>
-        <file>
-          <exists>package.json</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <version>1.3.0</version>
-            <executions>
-              <execution>
-                <id>get-node</id>
-                <phase>initialize</phase>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <configuration>
-                  <url>https://nodejs.org/dist/v${node.version}/${node.download.file}</url>
-                  <unpack>false</unpack>
-                  <outputDirectory>
-                    ${project.build.directory}/frontend/v${node.version}${node.download.classifier}
-                  </outputDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>get-npm</id>
-                <phase>initialize</phase>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <configuration>
-                  <url>http://registry.npmjs.org/npm/-/npm-${npm.version}.tgz</url>
-                  <unpack>false</unpack>
-                  <outputDirectory>${project.build.directory}/frontend/</outputDirectory>
-                  <outputFileName>npm-${npm.version}.tgz</outputFileName>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>node-execution</id>
       <activation>
         <file>
@@ -1146,8 +1037,6 @@
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <npmVersion>${npm.version}</npmVersion>
-                  <!-- Use the pre-download node and npm packages. See download-maven-plugin config above. -->
-                  <downloadRoot>${project.baseUri}target/frontend/</downloadRoot>
                 </configuration>
               </execution>
 


### PR DESCRIPTION
[JENKINS-43411](https://issues.jenkins-ci.org/browse/JENKINS-43411)

Two parts to this PR:
- Original motivation was to add support for the "yarn" package manager as an alternative to npm, which has given us many issues. This is done in 0a56287 and 	959283c.
-- There is some duplication between the configs for npm and yarn. I originally wanted to put this in a common profile, but I couldn't find a way to activate that one profile based on the presence of either marker file, as Maven only seems to support "AND" semantics when multiple files are listed.
- 87f0aef removes custom config for maven-download-plugin to download node and npm binaries. The original motivation for this config was that maven-frontend-plugin did not cache these across builds, so multi-module builds would repeatedly download the same artifacts. Adding support for yarn would have required some additional config here. I later discovered that MFP now caches artifacts inside of the machine's local Maven repo as a result of this PR: eirslett/frontend-maven-plugin#330
- Note: this is my first PR to a non-Blue Ocean repo, so apologies if I've missed any protocol or details.

@reviewbybees @tfennelly 