### PR TITLE
Introducing jenkins-core.version and jenkins-war.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,9 @@
     <arguments> </arguments>
     <argLine>-Djava.awt.headless=true</argLine>
     <jenkins.version>1.625.3</jenkins.version>
+    <!-- Should only need to override these if using timestamped snapshots: -->
+    <jenkins-core.version>${jenkins.version}</jenkins-core.version>
+    <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.18</jenkins-test-harness.version>
     <hpi-plugin.version>1.122</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
@@ -106,18 +109,18 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
-        <version>${jenkins.version}</version>
+        <version>${jenkins-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-war</artifactId>
-        <version>${jenkins.version}</version>
+        <version>${jenkins-war.version}</version>
         <classifier>war-for-test</classifier>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-war</artifactId>
-        <version>${jenkins.version}</version>
+        <version>${jenkins-war.version}</version>
         <type>war</type>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Since timestamped snapshots are not set to consistent versions in multimodule reactors by `mvn deploy`.

@reviewbybees