### PR TITLE
[INFRA-1139] Load node and npm from the Jenkins Artifactory rather than a third-party server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1028,54 +1028,6 @@
             </executions>
           </plugin>
           <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-dependency-plugin</artifactId>
-              <version>3.0.0</version>
-              <executions>
-                  <!-- TODO how to avoid downloading them all? -->
-                  <execution>
-                      <id>download node for Linux</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:linux-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download node for Darwin</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:darwin-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download node for Windows</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:exe:windows-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download npm</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:npm:${npm.version}:tar.gz</artifact>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-          <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <version>${frontend-version}</version>
@@ -1091,6 +1043,8 @@
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <npmVersion>${npm.version}</npmVersion>
+                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-tools/</nodeDownloadRoot>
+                  <npmDownloadRoot>https://repo.jenkins-ci.org/npm-tools/</npmDownloadRoot>
                 </configuration>
               </execution>
 
@@ -1165,54 +1119,6 @@
             </executions>
           </plugin>
           <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-dependency-plugin</artifactId>
-              <version>3.0.0</version>
-              <executions>
-                  <!-- TODO as above -->
-                  <execution>
-                      <id>download node for Linux</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:linux-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download node for Darwin</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:darwin-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download node for Windows</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:node:${node.version}:exe:windows-x64</artifact>
-                      </configuration>
-                  </execution>
-                  <execution>
-                      <id>download yarn</id>
-                      <phase>initialize</phase>
-                      <goals>
-                          <goal>get</goal>
-                      </goals>
-                      <configuration>
-                          <artifact>com.github.eirslett:yarn:${yarn.version}:tar.gz</artifact>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-          <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <version>${frontend-version}</version>
@@ -1228,6 +1134,8 @@
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <yarnVersion>v${yarn.version}</yarnVersion>
+                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-tools/</nodeDownloadRoot>
+                  <!-- tried to create a mirror for yarnDownloadRoot but it did not work -->
                 </configuration>
               </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1043,8 +1043,8 @@
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <npmVersion>${npm.version}</npmVersion>
-                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-tools/</nodeDownloadRoot>
-                  <npmDownloadRoot>https://repo.jenkins-ci.org/npm-tools/</npmDownloadRoot>
+                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
+                  <npmDownloadRoot>https://repo.jenkins-ci.org/npm-dist/</npmDownloadRoot>
                 </configuration>
               </execution>
 
@@ -1134,7 +1134,7 @@
                 <configuration>
                   <nodeVersion>v${node.version}</nodeVersion>
                   <yarnVersion>v${yarn.version}</yarnVersion>
-                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-tools/</nodeDownloadRoot>
+                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
                   <!-- tried to create a mirror for yarnDownloadRoot but it did not work -->
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1028,6 +1028,54 @@
             </executions>
           </plugin>
           <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                  <!-- TODO how to avoid downloading them all? -->
+                  <execution>
+                      <id>download node for Linux</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:linux-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download node for Darwin</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:darwin-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download node for Windows</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:exe:windows-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download npm</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:npm:${npm.version}:tar.gz</artifact>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
+          <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
             <version>${frontend-version}</version>
@@ -1115,6 +1163,54 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <version>3.0.0</version>
+              <executions>
+                  <!-- TODO as above -->
+                  <execution>
+                      <id>download node for Linux</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:linux-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download node for Darwin</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:tar.gz:darwin-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download node for Windows</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:node:${node.version}:exe:windows-x64</artifact>
+                      </configuration>
+                  </execution>
+                  <execution>
+                      <id>download yarn</id>
+                      <phase>initialize</phase>
+                      <goals>
+                          <goal>get</goal>
+                      </goals>
+                      <configuration>
+                          <artifact>com.github.eirslett:yarn:${yarn.version}:tar.gz</artifact>
+                      </configuration>
+                  </execution>
+              </executions>
           </plugin>
           <plugin>
             <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
[INFRA-1139](https://issues.jenkins-ci.org/browse/INFRA-1139)

Put load only on our own server, or (soon) a mirror thereof.

Would be nicer to define `nodeDownloadRoot` / `npmDownloadRoot` / `yarnDownloadRoot`, but that would require Artifactory to mirror those download sites in their original directory structure, and I am not sure if it can be configured to do that; whereas this PR makes no special assumptions: the layout is that of any old Maven artifact.

@reviewbybees esp. @cliffmeyers