### PR TITLE
Using requireMavenVersion, not prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,6 @@
     <hudson.Main.development>true</hudson.Main.development>
   </properties>
 
-  <prerequisites>
-    <maven>3.1.0</maven>
-  </prerequisites>
-
   <dependencyManagement>
     <dependencies>
       <!-- static analysis -->
@@ -490,8 +486,8 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0.4,)</version>
-                  <message>Maven 3.0 through 3.0.3 inclusive do not pass correct settings.xml to Maven Release Plugin.</message>
+                  <version>[3.1.0,)</version>
+                  <message>3.1.0 required by frontend-maven-plugin at least.</message>
                 </requireMavenVersion>
                 <requirePluginVersions>
                   <banSnapshots>false</banSnapshots>


### PR DESCRIPTION
Amends #53. Maven 3.5.0 warns you that

> The project org.jenkins-ci.plugins:plugin:pom:2.30-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html

Indeed we were only requiring 3.0.4, which was incorrect.

BTW: [reference for the 3.1.0 minimum](https://github.com/eirslett/frontend-maven-plugin/blob/b5a7ef6346cb4abc8fb38f6380a57c4c569302db/frontend-maven-plugin/pom.xml#L42)

@reviewbybees