### PR TITLE
Make failOnError=true the default for frontend-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1010,6 +1010,10 @@
             <artifactId>frontend-maven-plugin</artifactId>
             <version>${frontend-version}</version>
 
+            <configuration>
+              <failOnError>true</failOnError>
+            </configuration>
+
             <executions>
 
               <execution>


### PR DESCRIPTION
Though surprising in my opinion, the default behaviour of `frontend-maven-plugin` seems to not fail on errors. 

@reviewbybees 

With this, the effective pom becomes as follows:

```
      <plugin>
        <groupId>com.github.eirslett</groupId>
        <artifactId>frontend-maven-plugin</artifactId>
        <version>1.4</version>
        <executions>
          <execution>
            <id>install node and npm</id>
            <phase>initialize</phase>
            <goals>
              <goal>install-node-and-npm</goal>
            </goals>
            <configuration>
              <nodeVersion>v4.0.0</nodeVersion>
              <npmVersion>2.13.1</npmVersion>
              <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
              <npmDownloadRoot>https://repo.jenkins-ci.org/npm-dist/</npmDownloadRoot>
              <failOnError>true</failOnError>
            </configuration>
          </execution>
          <execution>
            <id>npm install</id>
            <phase>initialize</phase>
            <goals>
              <goal>npm</goal>
            </goals>
            <configuration>
              <arguments>install</arguments>
              <failOnError>true</failOnError>
            </configuration>
          </execution>
          <execution>
            <id>npm mvnbuild</id>
            <phase>generate-sources</phase>
            <goals>
              <goal>npm</goal>
            </goals>
            <configuration>
              <arguments>run mvnbuild</arguments>
              <failOnError>true</failOnError>
            </configuration>
          </execution>
          <execution>
            <id>npm mvntest</id>
            <phase>test</phase>
            <goals>
              <goal>npm</goal>
            </goals>
            <configuration>
              <arguments>run mvntest</arguments>
              <failOnError>true</failOnError>
            </configuration>
          </execution>
        </executions>
        <configuration>
          <failOnError>true</failOnError>
        </configuration>
      </plugin>
```