### PR TITLE
Need to exclude JNA from requireUpperBoundDeps for old core versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
                     <exclude>commons-logging:commons-logging</exclude> <!-- TODO jenkins-test-harness-htmlunit requests 1.2, newer than 1.1.x in core -->
                     <exclude>com.google.code.findbugs:jsr305</exclude> <!-- Stapler requests 2.x while core requests 1.x; anyway not used at runtime -->
                     <exclude>org.kohsuke:access-modifier-annotation</exclude> <!-- needed between Jenkins 2.36—2.60 -->
+                    <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>


### PR DESCRIPTION
@reviewbybees