### PR TITLE
Specify the default max memory for surefire.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <argLine>-Djava.awt.headless=true</argLine>
+    <argLine>-Xmx756M -Djava.awt.headless=true</argLine>
     <jenkins.version>1.625.3</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots: -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>


### PR DESCRIPTION
By default the max memory used by surefire will depend on the system.
This however has several issues, on a machine with lots of RAM but not a
huge amount spare each surefire JVM may by default try and grab 2GB of
ram, causing (when concurrency > 1 is used) the build to run out of
memory.
756MB was chosed as it is a multple of 256MB and was enough for a large
complex project with lots of JenkinsRule type tests.

@reviewbybees 