### PR TITLE
exclude icon-shim from RequireUpperBounds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
                     <exclude>commons-logging:commons-logging</exclude> <!-- TODO jenkins-test-harness-htmlunit requests 1.2, newer than 1.1.x in core -->
                     <exclude>com.google.code.findbugs:jsr305</exclude> <!-- Stapler requests 2.x while core requests 1.x; anyway not used at runtime -->
                     <exclude>org.kohsuke:access-modifier-annotation</exclude> <!-- needed between Jenkins 2.36—2.60 -->
+                    <exclude>org.jenkins-ci.plugins.icon-shim:icon-set</exclude> <!-- jenkins uses 1.0.3, icon-shim plugin uses later version -->
                     <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>
                 </requireUpperBoundDeps>


### PR DESCRIPTION
Jenkins-core depends on `org.jenkins-ci.plugins.icon-shim:icon-set:1.0.5` (version depends on core) yet plugins depending on `icon-shim` get different versions

e.g. 
```
matrix-auth 1.4 -> icon-shim 2.0.3 -> icon-set 2.0.3
jenkins-core 2.60 -> icon-set 1.0.5
```

@reviewbybees 