### PR TITLE
[JENKINS-41631] Make requireUpperBoundDeps work better with new cores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     -->
     <javadoc.exec.goal>javadoc</javadoc.exec.goal>
 
-    <slf4jVersion>1.7.7</slf4jVersion>
+    <slf4jVersion>1.7.25</slf4jVersion>
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
     <yarn.version>0.23.0</yarn.version>
@@ -175,7 +175,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
+        <version>1.2</version>
         <scope>provided</scope><!-- by jcl-over-slf4j -->
       </dependency>
       <dependency>
@@ -321,7 +321,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.2.jenkins-1</version> <!-- TODO update to official 1.4.2 or 3.0.0 when available -->
+          <version>3.0.0-M1</version> <!-- TODO 3.0.0 when released -->
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -528,9 +528,9 @@
                 </requireReleaseDeps>
                 <requireUpperBoundDeps>
                   <excludes>
-                    <exclude>com.google.guava:guava</exclude> <!-- TODO Stapler requests 14 while Jenkins requests 11; should backdate the Stapler version -->
-                    <exclude>commons-logging:commons-logging</exclude> <!-- TODO jenkins-test-harness-htmlunit requests 1.2, newer than 1.1.x in core -->
-                    <exclude>com.google.code.findbugs:jsr305</exclude> <!-- Stapler requests 2.x while core requests 1.x; anyway not used at runtime -->
+                    <exclude>com.google.guava:guava</exclude> <!-- TODO needed for Jenkins 2.71 and earlier -->
+                    <exclude>commons-logging:commons-logging</exclude> <!-- ditto -->
+                    <exclude>com.google.code.findbugs:jsr305</exclude> <!-- ditto -->
                     <exclude>org.kohsuke:access-modifier-annotation</exclude> <!-- needed between Jenkins 2.36—2.60 -->
                     <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>


### PR DESCRIPTION
Amends #67 and intended to work with https://github.com/jenkinsci/jenkins/pull/2956.

@reviewbybees