### PR TITLE
Update jenkins-test-harness to 2.27 to pick up JENKINS-45245 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Should only need to override these if using timestamped snapshots: -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.23</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.27</jenkins-test-harness.version>
     <hpi-plugin.version>2.0</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins-test-harness/pull/73. Also picks up [various other changes](https://github.com/jenkinsci/jenkins-test-harness/blob/master/README.md#227-2017-sep-20). (Note that 2.26 is already in use in core.)

@reviewbybees @jenkinsci/code-reviewers