### PR TITLE
[JENKINS-37062] servlet 3.1 dance...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
     <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>2.7</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots: -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
@@ -211,11 +211,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -533,6 +528,8 @@
                     <exclude>com.google.code.findbugs:jsr305</exclude> <!-- ditto -->
                     <exclude>org.kohsuke:access-modifier-annotation</exclude> <!-- needed between Jenkins 2.36—2.60 -->
                     <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
+                    <!-- artifactId changed and to prevent duplicate classes Jenkins 2.82+ force version 0 -->
+                    <exclude>javax.servlet:servlet-api</exclude> <!-- TODO remove when in jenkins plugin-pom  -->
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>


### PR DESCRIPTION
Jenkins has required the servlet 3.1 API since version 2.0

However the dependency you get in plugins is 2.5 which causes the build
classpath to contain old signatures and does not flag when you are not
implementing a new required API.

Whilst the original dance (#17) of keeping backwards compatability with old
cores was worthwhile 2.0 (and 2.7) are now sufficently old that I do not
beleive this dance is waranted, and it did not work anyway for the above
reasons.  So bump the baseline core to 2.7 and use 3.1.

Configures the enforce rule to not care about the Upper Bounds on the
legacy artifactId.

see also jenkinsci/jenkins#3033

@reviewbybees