### PR TITLE
Update FindBugs Maven Plugin to 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.4</version>
+          <version>3.0.5</version>
         </plugin>
         <plugin>
           <artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
Just picks new FindBugs patches.

Ideally we should migrate to [SpotBugs](https://github.com/spotbugs/spotbugs) when it gets stabilized.

@reviewbybees
