### PR TITLE
Don't set stupid defaults.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
-    <concurrency>1</concurrency> <!-- may use e.g. 2C for 2 × (number of cores) -->
+    <concurrency>1</concurrency> <!-- DEPRECATED use forkCount -->
+    <forkCount>${concurrency}</forkCount> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
     <!-- Whether the build should fail if findbugs finds any error. -->
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
@@ -689,11 +690,9 @@
           <systemProperties>
             <property>
               <name>hudson.udp</name>
-              <value>33849</value>
+              <value>-1</value>
             </property>
           </systemProperties>
-          <reuseForks>true</reuseForks>
-          <forkCount>${concurrency}</forkCount>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I doubt any plugin cares about multicast dns discovery so just disable
it rather than giving it a non standard port (which could lead to
announcments on a public wifi network)

Also `reuseForks` is true by default so do not set it and allow users to
use the standard `-DreuseForks=false` without having to change the plugin
config.

On the same note `concurrency` is only ever used in surefires `forkCount` -
yet another non standard property.  So stop that nonsense and use
`forkCount` directly (which is initialized to concurrency for backwards
compatability)

Tested on a plugin with an updated snapshot parent using 
`mvn test` (check concurrency is one test at once)
`mvn test -Dconcurrency=4` (check concurrency if 4 at once - for backwards comparability)
`mvn test -DforkCount=4` (check concurrency is 4 at once)

@reviewbybees