### PR TITLE
Remove rerunFailingTest profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -875,17 +875,6 @@
       </properties>
     </profile>
     <profile>
-      <id>rerunFailingTests</id>
-      <activation>
-        <property>
-          <name>!test</name>
-        </property>
-      </activation>
-      <properties>
-        <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
-      </properties>
-    </profile>
-    <profile>
       <id>skip-findbugs-with-tests</id>
       <activation>
         <property>


### PR DESCRIPTION
This encourages flaky tests. Also will make tests longer with possibly nobody noticing the reruns.

If really, someone wants to do this, anyone can do it in a *very* simple way.
But let's not encourage people to write flakes.

Either by using the CLI on an exceptional basis:

```
mvn -Dsurefire.rerunFailingTestsCount=2 test
```

Or by putting that property in their own plugin pom.

@reviewbybees esp. @jtnord 