### PR TITLE
jenkins-test-harness 2.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Should only need to override these if using timestamped snapshots: -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.28</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.31</jenkins-test-harness.version>
     <hpi-plugin.version>2.1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>7</java.level>


### PR DESCRIPTION
[Changelog](https://github.com/jenkinsci/jenkins-test-harness/#231-2017-oct-17)

Most notable change is picking up https://github.com/jenkinsci/jenkins-test-harness/pull/79 to be able to test `-Djenkins.version=2.86` and later; see [JENKINS-47393](https://issues.jenkins-ci.org/browse/JENKINS-47393). (AFAIK `plugin-compat-tester` is unaffected by that since it adds synthetic deps on detached plugins.)

@reviewbybees