### PR TITLE
Make FindBugs effort and threshold configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,12 @@
     <!-- Whether the build should fail if findbugs finds any error. -->
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
     <findbugs.failOnError>true</findbugs.failOnError>
-    <!-- Defines a default FindBugs threshold. -->
-    <!-- In Plugin POM 2.x the default value was Medium, but it was not enough to discover some null handling cases -->
-    <findbugs.threshold>Low</findbugs.threshold>
+    <!-- Defines a FindBugs threshold. Use "Low" to discover low-priority bugs.
+         Hint: FindBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
+      -->
+    <findbugs.threshold>Medium</findbugs.threshold>
+    <!-- Defines a FindBugs effor. Use "Max" to maximize the scan depth -->
+    <findbugs.effort>default</findbugs.effort>
     
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
@@ -569,7 +572,7 @@
               <!--  Instead we configure this in a profile -->
               <xmlOutput>true</xmlOutput>
               <findbugsXmlOutput>false</findbugsXmlOutput>
-              <effort>Max</effort>
+              <effort>${findbugs.effort}</effort>
               <threshold>${findbugs.threshold}</threshold>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
     <!-- Whether the build should fail if findbugs finds any error. -->
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
     <findbugs.failOnError>true</findbugs.failOnError>
+    <!-- Defines a default FindBugs threshold. -->
+    <!-- In Plugin POM 2.x the default value was Medium, but it was not enough to discover some null handling cases -->
+    <findbugs.threshold>Low</findbugs.threshold>
+    
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
     <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
@@ -566,6 +570,8 @@
               <!--  Instead we configure this in a profile -->
               <xmlOutput>true</xmlOutput>
               <findbugsXmlOutput>false</findbugsXmlOutput>
+              <effort>Max</effort>
+              <threshold>${findbugs.threshold}</threshold>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
          Hint: FindBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
     <findbugs.threshold>Medium</findbugs.threshold>
-    <!-- Defines a FindBugs effor. Use "Max" to maximize the scan depth -->
+    <!-- Defines a FindBugs effort. Use "Max" to maximize the scan depth -->
     <findbugs.effort>default</findbugs.effort>
     
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->


### PR DESCRIPTION
This change makes the default configuration of FindBugs much more paranoid about potential issues. #83 bumps the Parent POM to 3.x, so I feel it is a good time to introduce it.

On the Low level there are some Not-important issues, but the experience in https://github.com/jenkinsci/envinject-lib/pull/13/ shows that otherwise we may miss real NPE risks in Jenkins.

@reviewbybees @jglick @batmat 