### PR TITLE
Added a default license definition for all Jenkins plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,13 @@
     <tag>HEAD</tag>
   </scm>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://jenkins.io/license</url>
+    </license>
+  </licenses>
+
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>


### PR DESCRIPTION
The motivation behind of this change is to provide a default license definition for all Jenkins plugins. In that way, plugins like [license-maven-plugin](http://www.mojohaus.org/license-maven-plugin/) are able to work properly.

@jenkinsci/code-reviewers, specially, @rtyler, @daniel-beck and @andresrc
