### PR TITLE
Link back to the Jenkins javadoc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,11 @@
             </goals>
             <!-- As soon as possible but after required generate-sources phase -->
             <phase>process-sources</phase>
+            <configuration>
+              <links>
+                <link>http://javadoc.jenkins.io/</link>
+              </links>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Since most plugins will use classes from Jenkins we should link the
javadoc so you can navigate to the Jenkins javadoc similar to linking to
the J2SE javadoc

Tested on a local plugin that the links to the jenkins javadoc and the Oracle J2SE javadocs are created.

@reviewbybees