### PR TITLE
Force java.level to be overridden in children

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This new parent POM is decoupled from the core Jenkins project, both from the Ma
 The main changes are:
 * Reduced number of overridable properties. All references (e.g. dependencies and plugin versions) not
 thought to be overridden are no longer based on properties. The main remaining overridable properties are:
-  * `jenkins.version`: The Jenkins version required by the plugin.
+  * `jenkins.version`: The Jenkins version required by the plugin. **Mandatory.**
+  * `java.level`: The Java version to use to build the plugin. **Mandatory.** Should match the minimum Java version for the selected Jenkins version.
   * `jenkins-test-harness.version`: The [JTH version](https://github.com/jenkinsci/jenkins-test-harness/releases) used to test plugin.
   Uses split test-harness (see [JENKINS-32478](https://issues.jenkins-ci.org/browse/JENKINS-32478)).
   If the required Jenkins version is 1.580.1 or higher, JTH 2.1+ is recommended.
   * `hpi-plugin.version`: The HPI Maven Plugin version used by the plugin.
   (Generally you should not set this to a version _lower_ than that specified in the parent POM.)
   * `stapler-plugin.version`: The Stapler Maven plugin version required by the plugin.
-  * `java.level`: The Java version to use to build the plugin.
   * `java.level.test`: The Java version to use to build the plugin tests.
   * In order to make their versions the same as the used core version, `slf4jVersion`, `node.version` and `npm.version`
   properties are provided.
@@ -43,6 +43,7 @@ In order to use the new POM:
 ```xml
   <properties>
     <jenkins.version>1.609.1</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 ```
 
@@ -60,9 +61,23 @@ For example:
 
 ```xml
 <profile>
+    <id>jenkins-289</id>
+    <properties>
+        <jenkins.version>2.89</jenkins.version>
+        <java.level>8</java.level>
+    </properties>
+</profile>
+<profile>
+    <id>jenkins-273</id>
+    <properties>
+        <jenkins.version>2.73.3</jenkins.version>
+        <java.level>8</java.level>
+    </properties>
+</profile>
+<profile>
     <id>jenkins-260</id>
     <properties>
-        <jenkins.version>2.60.2</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <jenkins-test-harness.version>2.31</jenkins-test-harness.version>
     <hpi-plugin.version>2.1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
-    <java.level>8</java.level>
+    <java.level>you-must-override-the-java.level-property</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
@@ -765,6 +765,17 @@
 
   <profiles>
     <profile>
+      <id>uninherited-java.level</id>
+      <activation>
+        <file>
+          <exists>${basedir}/src/it/undefined-java-level/pom.xml</exists> <!-- just something that is only here -->
+        </file>
+      </activation>
+      <properties>
+        <java.level>8</java.level>
+      </properties>
+    </profile>
+    <profile>
       <id>jenkins-release</id>
       <properties>
         <skipTests>${release.skipTests}</skipTests>
@@ -1281,7 +1292,6 @@
                 <configuration>
                   <streamLogs>false</streamLogs>
                   <showErrors>true</showErrors>
-                  <debug>true</debug>
                   <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
                   <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
                   <settingsFile>src/it/settings.xml</settingsFile>

--- a/src/it/undefined-java-level/invoker.properties
+++ b/src/it/undefined-java-level/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean install
+invoker.buildResult=failure

--- a/src/it/undefined-java-level/pom.xml
+++ b/src/it/undefined-java-level/pom.xml
@@ -9,12 +9,11 @@
         <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>sample-plugin</artifactId>
+    <artifactId>undefined-java-level</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.32.3</jenkins.version>
-        <java.level>7</java.level>
     </properties>
     <repositories>
         <repository>
@@ -28,11 +27,4 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/src/it/undefined-java-level/postbuild.groovy
+++ b/src/it/undefined-java-level/postbuild.groovy
@@ -1,0 +1,3 @@
+assert new File(basedir, 'build.log').text.contains('java.lang.IllegalArgumentException: Unknown JDK version given. Should be something like "1.7"')
+
+return true

--- a/src/it/undefined-java-level/src/main/java/test/X.java
+++ b/src/it/undefined-java-level/src/main/java/test/X.java
@@ -1,0 +1,3 @@
+package test;
+
+public class X {}

--- a/src/it/undefined-java-level/src/main/resources/index.jelly
+++ b/src/it/undefined-java-level/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>


### PR DESCRIPTION
Makes #83 safer by making sure people (like me, twice) do not forget to override `java.level` when updating to a 3.x POM. Based on a trick suggested by @batmat in https://github.com/jenkinsci/durable-task-plugin/pull/53.

@reviewbybees