### PR TITLE
requireJavaVersion to enforce use of JDK 8+ when building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,9 @@
                   <version>[3.1.0,)</version>
                   <message>3.1.0 required by frontend-maven-plugin at least.</message>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8.0,)</version>
+                </requireJavaVersion>
                 <requirePluginVersions>
                   <banSnapshots>false</banSnapshots>
                 </requirePluginVersions>


### PR DESCRIPTION
As of https://github.com/jenkinsci/maven-hpi-plugin/pull/62 we need JDK 8 to run builds, so do not even let people try to build on JDK 7. (You can still specify `java.level=7` of course, or perhaps even earlier.)

@reviewbybees