### PR TITLE
jenkins-test-harness.version=2.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Should only need to override these if using timestamped snapshots: -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.31</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.32</jenkins-test-harness.version>
     <hpi-plugin.version>2.1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>


### PR DESCRIPTION
[Changelog](https://github.com/jenkinsci/jenkins-test-harness/#232-2017-oct-28); in particular I want to get https://github.com/jenkinsci/jenkins-test-harness/pull/81 out there for use by a bunch of plugins to fix PCT failures from https://github.com/jenkinsci/jenkins/pull/3120.

@reviewbybees