### PR TITLE
Add more standard enforceBytecodeVersion exclusions, for Remoting and Stapler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,11 @@
                     <exclude>org.jenkins-ci.main:jenkins-core</exclude>
                     <exclude>org.jenkins-ci.main:cli</exclude>
                     <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
                     <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
                   </excludes>

--- a/src/it/not-newest-java-level/invoker.properties
+++ b/src/it/not-newest-java-level/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean install

--- a/src/it/not-newest-java-level/pom.xml
+++ b/src/it/not-newest-java-level/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>@project.version@</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>not-newest-java-level</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>2.89</jenkins.version>
+        <java.level>7</java.level>
+    </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/it/not-newest-java-level/src/main/java/test/X.java
+++ b/src/it/not-newest-java-level/src/main/java/test/X.java
@@ -1,0 +1,3 @@
+package test;
+
+public class X {}

--- a/src/it/not-newest-java-level/src/main/resources/index.jelly
+++ b/src/it/not-newest-java-level/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>


### PR DESCRIPTION
These were recently updated to Java 8. Without this patch, a plugin normally using some pre-2.60.x baseline cannot request

```groovy
buildPlugin(jenkinsVersions: [null, '2.89'])
```

since passing `-Djenkins.version=2.89` without adding `-Djava.level=8` causes this rule to complain that Remoting and Stapler have Java 8 bytecode. The purpose of the rule is to block you from _bundling_ class files using newer bytecode than your baseline allows, not to check stuff in the core classpath, which is why we were already excluding Jenkins core artifacts.

Note that this is in some sense the opposite of https://github.com/jenkinsci/plugin-pom/pull/88#pullrequestreview-80097814.

@reviewbybees