### PR TITLE
surefire.runOrder=alphabetical for reproducibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -692,6 +692,7 @@
               <value>-1</value>
             </property>
           </systemProperties>
+          <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
For some reason this [defaults to `filesystem`](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder), which is semirandom: all test suites within a package will be run as a group, but in an unpredictable order. To reduce sources of nondeterminism it is best to always run the exact same sequence of suites.

(If you isolate each test suite, as I had to do in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/42, it probably makes no difference. But by default we reuse test JVMs, so it is possible for one suite to somehow pollute others, in which case you could wind up with errors that do not reproduce locally.)

As of https://github.com/junit-team/junit4/pull/293 test cases within a suite are run in a deterministic order.

@reviewbybees