### PR TITLE
expose JTH "jenkins.test.noSpaceInTmpDirs" property as a Maven property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
     <maven-scm.version>1.9.5</maven-scm.version>
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
+    <!--
+      Starting with 2.33, jenkins-test-harness puts a space character in the path of the temporary workdir of agents
+      created from JenkinsRule.  It can help catching shell quoting bugs.  If your plugin's tests break because of this
+      and it can't be fixed, then you can disable this behavior by setting "jenkins.test.noSpaceInTmpDirs" to "true".
+    -->
+    <jenkins.test.noSpaceInTmpDirs>false</jenkins.test.noSpaceInTmpDirs>
   </properties>
 
   <dependencyManagement>
@@ -695,6 +701,10 @@
             <property>
               <name>hudson.udp</name>
               <value>-1</value>
+            </property>
+            <property>
+              <name>jenkins.test.noSpaceInTmpDirs</name>
+              <value>${jenkins.test.noSpaceInTmpDirs}</value>
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.45</jenkins-test-harness.version>
     <hpi-plugin.version>3.1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.45</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.46</jenkins-test-harness.version>
     <hpi-plugin.version>3.2</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>


### PR DESCRIPTION
This is to go with jenkinsci/jenkins-test-harness#89, if it gets merged.  I added a system property in JTH that some plugin might want to change, and this PR is to add the corresponding Maven property and passing it to surefire.

Note that there is no point in merging this unless the JTH PR gets merged and released first, and the JTH version in plugin-pom gets updated.  My comment in the pom.xml mentions JTH version "2.33", this might need editing depending on what actually happens.