### PR TITLE
Exclude org.jenkins-ci:task-reactor from enforceBytecodeVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,7 @@
                     <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
                     <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
                     <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
+                    <exclude>org.jenkins-ci:task-reactor</exclude>
                     <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
                   </excludes>


### PR DESCRIPTION
After https://github.com/jenkinsci/lib-task-reactor/pull/2 in 2.105, plugins using `java.level=7` need this in order to build.

@reviewbybees