### PR TITLE
access-modifier-checker 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <plugin>
           <groupId>org.kohsuke</groupId>
           <artifactId>access-modifier-checker</artifactId>
-          <version>1.8</version>
+          <version>1.13</version>
         </plugin>
         <plugin>
           <groupId>com.cloudbees</groupId>


### PR DESCRIPTION
Most notably picks up https://github.com/kohsuke/access-modifier/pull/7 & https://github.com/kohsuke/access-modifier/pull/10.

@reviewbybees