### PR TITLE
During release:perform, we already skip tests, and there is no need to rerun FindBugs either—save a bit of time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -817,6 +817,7 @@
       <id>jenkins-release</id>
       <properties>
         <skipTests>${release.skipTests}</skipTests>
+        <findbugs.skip>${release.skipTests}</findbugs.skip>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Extracted from #100.