### PR TITLE
Preconfigure incrementals-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,19 @@
           <artifactId>maven-license-plugin</artifactId>
           <version>1.7</version>
         </plugin>
+        <plugin> <!-- not gated by Incrementals profiles, since we want the incrementalify goal to be available from the start -->
+          <groupId>io.jenkins.tools.incrementals</groupId>
+          <artifactId>incrementals-maven-plugin</artifactId>
+          <version>1.0-beta-3</version>
+          <configuration>
+            <includes>
+              <include>org.jenkins-ci.*</include>
+              <include>io.jenkins.*</include>
+            </includes>
+            <generateBackupPoms>false</generateBackupPoms>
+            <updateNonincremental>false</updateNonincremental>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1283,25 +1296,6 @@
           </snapshots>
         </pluginRepository>
       </pluginRepositories>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>io.jenkins.tools.incrementals</groupId>
-              <artifactId>incrementals-maven-plugin</artifactId>
-              <version>1.0-alpha-3</version>
-              <configuration>
-                <includes>
-                  <include>org.jenkins-ci.*</include>
-                  <include>io.jenkins.*</include>
-                </includes>
-                <generateBackupPoms>false</generateBackupPoms>
-                <updateNonincremental>false</updateNonincremental>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
     </profile>
     <profile>
       <id>might-produce-incrementals</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1283,6 +1283,25 @@
           </snapshots>
         </pluginRepository>
       </pluginRepositories>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>io.jenkins.tools.incrementals</groupId>
+              <artifactId>incrementals-maven-plugin</artifactId>
+              <version>1.0-alpha-2</version>
+              <configuration>
+                <includes>
+                  <include>org.jenkins-ci.*</include>
+                  <include>io.jenkins.*</include>
+                </includes>
+                <generateBackupPoms>false</generateBackupPoms>
+                <updateNonincremental>false</updateNonincremental>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>might-produce-incrementals</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1289,7 +1289,7 @@
             <plugin>
               <groupId>io.jenkins.tools.incrementals</groupId>
               <artifactId>incrementals-maven-plugin</artifactId>
-              <version>1.0-alpha-2</version>
+              <version>1.0-alpha-3</version>
               <configuration>
                 <includes>
                   <include>org.jenkins-ci.*</include>


### PR DESCRIPTION
Exposes [JENKINS-50953](https://issues.jenkins-ci.org/browse/JENKINS-50953) to plugins consuming incrementals: you can

```bash
mvn incrementals:update
```

to get a newer version of some dependencies, if merged, or

```bash
mvn incrementals:update -Dbranch=jglick:experiments-JENKINS-12345
```

to get the most recent versions from some set of unmerged PRs.