### PR TITLE
[JENKINS-51247] Always use source:jar-no-fork, not source:jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -838,7 +838,7 @@
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
               <execution>


### PR DESCRIPTION
Analogue of https://github.com/jenkinsci/pom/pull/25, though simpler in this case since the plugin POM was already (for whatever reason) suppressing the standard `release-profile` and using its own `jenkins-release` profile.