### PR TITLE
Also prefer test-jar-no-fork to test-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -844,7 +844,7 @@
               <execution>
                 <id>attach-test-sources</id>
                 <goals>
-                  <goal>test-jar</goal>
+                  <goal>test-jar-no-fork</goal>
                 </goals>
                 <configuration>
                   <skipSource>${no-test-jar}</skipSource>


### PR DESCRIPTION
Follows up #107; somehow missed this one. This goal is used by a minority of plugins, for example https://github.com/jenkinsci/workflow-api-plugin/pull/67.