### PR TITLE
maven-hpi-plugin 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
-    <hpi-plugin.version>2.3</hpi-plugin.version>
+    <hpi-plugin.version>2.6</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->


### PR DESCRIPTION
[Changelog for 2.5 and 2.6](https://github.com/jenkinsci/maven-hpi-plugin/blob/master/README.md#26-2018-jun-01): picks up https://github.com/jenkinsci/maven-hpi-plugin/pull/80 & https://github.com/jenkinsci/maven-hpi-plugin/pull/81.