### PR TITLE
Java10 Hacking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,7 +506,7 @@
                 </requirePluginVersions>
                 -->
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <maxJdkVersion>${java.level}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
@@ -601,10 +601,10 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.${java.level}</source>
-          <target>1.${java.level}</target>
-          <testSource>1.${java.level.test}</testSource>
-          <testTarget>1.${java.level.test}</testTarget>
+          <source>${java.level}</source>
+          <target>${java.level}</target>
+          <testSource>${java.level.test}</testSource>
+          <testTarget>${java.level.test}</testTarget>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>plugin</artifactId>
-  <version>3.16-SNAPSHOT</version>
+  <version>3.16-java10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Jenkins Plugin Parent POM</name>
@@ -521,7 +521,7 @@
                     <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
                     <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
                     <exclude>org.jenkins-ci:task-reactor</exclude>
-                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing 3ations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
                   </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:
@@ -621,7 +621,8 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
+            <!-- Hardcoded unfortunately -->
+            <artifactId>java18</artifactId>
           </signature>
         </configuration>
       </plugin>
@@ -798,7 +799,7 @@
         </file>
       </activation>
       <properties>
-        <java.level>8</java.level>
+        <java.level>1.8</java.level>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -521,7 +521,7 @@
                     <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
                     <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
                     <exclude>org.jenkins-ci:task-reactor</exclude>
-                    <!--  findbugs dep managed to provided and optional so is not shipped and missing 3ations ok -->
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
                   </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:


### PR DESCRIPTION
* Handle Java version strings like "9" and "10" due to change in the nomenclature from 1.8, etc
    * Note that this requires all things taking up new plugin POM to change their java.level, i.e. "8" -> "1.8"

TODO:
* [ ] org.codehaus.mojo.signature artifactid hardcoded, because it does NOT include a period, i.e. 1.8 -> 18