### PR TITLE
[JENKINS-52097] - Update Animal Sniffer to 1.16 and make it configurable via Maven properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
     <!-- May be used to select timestamped snapshots: -->
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version>
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
+    <animal.sniffer.version>1.16</animal.sniffer.version>
     <!-- To opt in to @Restricted(Beta.class) APIs, set to true: -->
     <useBeta>false</useBeta>
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
@@ -148,7 +149,7 @@
       <dependency>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-annotations</artifactId>
-        <version>1.16</version>
+        <version>${animal.sniffer.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.mojo.signature</groupId>
@@ -429,7 +430,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.15</version>
+          <version>${animal.sniffer.version}</version>
         </plugin>
         <plugin>
           <groupId>org.jvnet.localizer</groupId>


### PR DESCRIPTION
In order to deliver/evaluate a fix for JENKINS-52007, it would be great to have the Animal Sniffer version configurable in Plugin POM. The version is currently used in two places, so it's also helpful w.r.t project consistency

https://issues.jenkins-ci.org/browse/JENKINS-52097

@jenkinsci/java10-support @olamy @ndeloof 