### PR TITLE
Update maven-site-plugin and add project-info-reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.6</version>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Fixes `mvn site` and a warning in the output - Currently, running `mvn site` inside any plugin project runs into an incompatibility between `maven-site` 3.6 and `maven-project-info-reports` 3.0.0:

```
[INFO] --- maven-site-plugin:3.6:site (default-site) @ plugin ---
[WARNING] Report plugin org.apache.maven.plugins:maven-project-info-reports-plugin has an empty version.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[INFO] configuring report plugin org.apache.maven.plugins:maven-project-info-reports-plugin:3.0.0
[WARNING] Error injecting: org.apache.maven.report.projectinfo.CiManagementReport
java.lang.NoClassDefFoundError: org/apache/maven/doxia/siterenderer/DocumentContent
[...]
```

To get rid of the conflict, update the site plugin to the latest version (3.7.1). Adding `maven-project-info-reports` just gets rid of the extra warning.

PS: Would it be useful to add a default "reporting" section into the plugin-pom? While I'm not a fan of building websites with "maven-site", it is quite useful to run locally, for example with the versions-maven-plugin, to get an overview about dependency updates.