### PR TITLE
Set java.io.tmpdir to ${basedir}/target/tmp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
     <!-- Where to put temporary files during test runs. -->
-    <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
+    <surefireTempDir>${project.build.directory}/tmp</surefireTempDir>
   </properties>
 
   <dependencyManagement>
@@ -722,7 +722,7 @@
             </property>
             <property>
               <name>java.io.tmpdir</name>
-              <value>${java.io.tmpdir}</value>
+              <value>${surefireTempDir}</value>
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
     <useBeta>false</useBeta>
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
+    <!-- Where to put temporary files during test runs. -->
+    <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
   </properties>
 
   <dependencyManagement>
@@ -720,7 +722,7 @@
             </property>
             <property>
               <name>java.io.tmpdir</name>
-              <value>${project.build.directory}/tmp</value>
+              <value>${java.io.tmpdir}</value>
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -718,6 +718,10 @@
               <name>hudson.udp</name>
               <value>-1</value>
             </property>
+            <property>
+              <name>java.io.tmpdir</name>
+              <value>${project.build.directory}/tmp</value>
+            </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
         </configuration>


### PR DESCRIPTION
The default system temp dir is not a great choice for dumping stuff produced by tests, especially for CI builds running inside a Docker container which run tests calling `withDockerContainer`, which passes `--volumes-from` and then explodes because `/tmp/jenkinsTests.tmp/` (cf. `TemporaryDirectoryAllocator` & #93 + https://github.com/jenkinsci/jenkins-test-harness/pull/89) is not on a volume (when the source checkout is). The system temp dir is also used by `TestPluginManager`, the `TemporaryFolder` rule, and so on. With this change, the typical `$JENKINS_HOME` moves from say `/tmp/jenkinsTests.tmp/jenkins8944848744570102525test` to `/…/jenkinsci/some-plugin/target/tmp/jenkinsTests.tmp/jenkins8944848744570102525test`.

Ideally `WarExploder` could also be simplified to use the system temp dir rather than `System.getProperty("buildDirectory", "target")`, especially if `gradle-jpi-plugin` is updated first, but this is hardly urgent.