### PR TITLE
Pick up fix of SUREFIRE-1588

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
     agent {
         docker {
-            image 'maven:3.5.0-jdk-8'
+            image 'maven:3.6.0-jdk-8'
             label 'docker'
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
[SUREFIRE-1588](https://issues.apache.org/jira/browse/SUREFIRE-1588): integrates https://github.com/apache/maven-surefire/pull/197, allowing tests to be run on Debian-based systems. The alternative is

```diff
diff --git a/pom.xml b/pom.xml
index 8d85d05..9a02755 100644
--- a/pom.xml
+++ b/pom.xml
@@ -742,6 +742,8 @@
               <value>${surefireTempDir}</value>
             </property>
           </systemProperties>
+          <!-- Too late for systemProperties: -->
+          <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>
```