### PR TITLE
A less intrusive workaround for SUREFIRE-1588

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
+    <!-- disableClassPathURLCheck is SUREFIRE-1588 workaround; too late for systemProperties: -->
+    <argLine>-Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
     <jenkins.version>2.60.1</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
@@ -742,8 +743,6 @@
               <value>${surefireTempDir}</value>
             </property>
           </systemProperties>
-          <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
-          <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>2.20</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
@@ -742,6 +742,8 @@
               <value>${surefireTempDir}</value>
             </property>
           </systemProperties>
+          <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
+          <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           <runOrder>alphabetical</runOrder>
         </configuration>
       </plugin>


### PR DESCRIPTION
#130 causes JEP-200 issues in our Windows builders pending https://github.com/apache/maven-surefire/pull/198, so I am offering a safer workaround.