### PR TITLE
Avoid http://www.slf4j.org/codes.html#release warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,11 @@
       <version>${access-modifier-annotation.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency> <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <!--

--- a/src/it/sample-plugin/postbuild.groovy
+++ b/src/it/sample-plugin/postbuild.groovy
@@ -13,6 +13,8 @@ try {
     j.close()
 }
 
+assert !new File(basedir, 'target/surefire-reports/test.SampleRootActionTest-output.txt').text.contains('http://www.slf4j.org/codes.html#release')
+
 // TODO check no-test-jar=false (cf. maven-hpi-plugin/src/it/parent-2x)
 // TODO check npm usage
 


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/jenkins-test-harness/pull/71 thanks to a tip from @jtnord.