### PR TITLE
[JENKINS-54828] - Support building plugins with java.level=11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1515,12 +1515,6 @@
              Tracked as https://issues.jenkins-ci.org/browse/JENKINS-54842
          -->
         <animal.sniffer.signature.version>java18</animal.sniffer.signature.version>
-
-        <!--
-          TODO: remove once Maven Enforcer rules are updated.
-          https://github.com/mojohaus/extra-enforcer-rules/pull/63 and https://issues.jenkins-ci.org/browse/JENKINS-54843
-        -->
-        <enforcer.skip>true</enforcer.skip>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,14 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
-    <hpi-plugin.version>2.7</hpi-plugin.version>
+    <hpi-plugin.version>2.8-20181123.072741-1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
+    <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
+    <plugin.tests.minimumJavaVersion>1.${java.level.test}</plugin.tests.minimumJavaVersion>
     <concurrency>1</concurrency> <!-- DEPRECATED use forkCount -->
     <forkCount>${concurrency}</forkCount> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
@@ -91,11 +93,13 @@
     <maven-scm.version>1.9.5</maven-scm.version>
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
-    <access-modifier.version>1.15</access-modifier.version>
+    <access-modifier.version>1.16</access-modifier.version>
     <!-- May be used to select timestamped snapshots: -->
     <access-modifier-annotation.version>${access-modifier.version}</access-modifier-annotation.version>
     <access-modifier-checker.version>${access-modifier.version}</access-modifier-checker.version>
+    <annotation-indexer.version>1.12</annotation-indexer.version>
     <animal.sniffer.version>1.17</animal.sniffer.version>
+    <animal.sniffer.signature.version>java1${java.level}</animal.sniffer.signature.version>
     <!-- To opt in to @Restricted(Beta.class) APIs, set to true: -->
     <useBeta>false</useBeta>
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
@@ -286,6 +290,12 @@
       <version>${access-modifier-annotation.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>annotation-indexer</artifactId>
+      <version>${annotation-indexer.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency> <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
@@ -334,7 +344,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M1</version> <!-- TODO 3.0.0 when released -->
+          <version>3.0.0-M2</version> <!-- TODO 3.0.0 when released -->
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
@@ -519,7 +529,7 @@
                 </requirePluginVersions>
                 -->
                 <enforceBytecodeVersion>
-                  <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                  <maxJdkVersion>${plugin.minimumJavaVersion}</maxJdkVersion>
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
@@ -614,10 +624,10 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.${java.level}</source>
-          <target>1.${java.level}</target>
-          <testSource>1.${java.level.test}</testSource>
-          <testTarget>1.${java.level.test}</testTarget>
+          <source>${plugin.minimumJavaVersion}</source>
+          <target>${plugin.minimumJavaVersion}</target>
+          <testSource>${plugin.tests.minimumJavaVersion}</testSource>
+          <testTarget>${plugin.tests.minimumJavaVersion}</testTarget>
         </configuration>
       </plugin>
       <plugin>
@@ -634,7 +644,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${java.level}</artifactId>
+            <artifactId>${animal.sniffer.signature.version}</artifactId>
           </signature>
         </configuration>
       </plugin>
@@ -648,7 +658,7 @@
         <configuration>
           <showDeprecation>true</showDeprecation>
           <contextPath>/jenkins</contextPath>
-          <!-- TODO specify ${java.level} when JENKINS-20679 implemented -->
+          <minimumJavaVersion>${plugin.minimumJavaVersion}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
           </systemProperties>
@@ -1487,6 +1497,43 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <!-- oleg_nenashev: Cannot setup activation for multiple Java versions:
+           https://issues.apache.org/jira/browse/MNG-3328
+       -->
+      <id>java-level-11</id>
+      <activation>
+        <property>
+          <name>java.level</name>
+          <value>11</value>
+        </property>
+      </activation>
+      <properties>
+        <plugin.minimumJavaVersion>${java.level}</plugin.minimumJavaVersion>
+        <!-- TODO(oleg_nenashev): disable it at all? Now we assume that the code is just compatible with Java 8 which is OK for now.
+             Tracked as https://issues.jenkins-ci.org/browse/JENKINS-54842
+         -->
+        <animal.sniffer.signature.version>java18</animal.sniffer.signature.version>
+
+        <!--
+          TODO: remove once Maven Enforcer rules are updated.
+          https://github.com/mojohaus/extra-enforcer-rules/pull/63 and https://issues.jenkins-ci.org/browse/JENKINS-54843
+        -->
+        <enforcer.skip>true</enforcer.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>java-test-level-11</id>
+      <activation>
+        <property>
+          <name>java.level.test</name>
+          <value>11</value>
+        </property>
+      </activation>
+      <properties>
+        <plugin.tests.minimumJavaVersion>${java.level.test}</plugin.tests.minimumJavaVersion>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
WiP version of the `java.level=11` support for building plugins. So far it does not quite work.

Upstream deps/issues:

* [x] - Minimum Java version in the manifest
  * https://github.com/jenkinsci/maven-hpi-plugin/pull/75 
* [x] - Extra Enforcer Rules: fails with Java 11
  * https://issues.jenkins-ci.org/browse/JENKINS-54843
  * https://github.com/mojohaus/extra-enforcer-rules/pull/63
* [ ] - Animal Sniffer Annotations: No annotations for Java 11 (CC @olamy )
  * https://issues.jenkins-ci.org/browse/JENKINS-54842
* [x] - Access Modifier crashes in ASM
  * https://issues.jenkins-ci.org/browse/JENKINS-54844
  * It seems we need to update ASM again for Java 11. 7.0 is still in Beta

@jenkinsci/java11-support 

