### PR TITLE
[JENKINS-20679] - Inject Minimum-Java-Version into the plugin manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,10 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
-    <hpi-plugin.version>2.7</hpi-plugin.version>
+    <hpi-plugin.version>2.8-20181123.072741-1</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
+    <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
@@ -648,7 +649,7 @@
         <configuration>
           <showDeprecation>true</showDeprecation>
           <contextPath>/jenkins</contextPath>
-          <!-- TODO specify ${java.level} when JENKINS-20679 implemented -->
+          <minimumJavaVersion>${plugin.minimumJavaVersion}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
           </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
-    <hpi-plugin.version>3.0-20181203.145945-2</hpi-plugin.version>
+    <hpi-plugin.version>3.0</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
-    <hpi-plugin.version>2.8-20181123.072741-1</hpi-plugin.version>
+    <hpi-plugin.version>3.0-20181203.145945-2</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/maven-hpi-plugin/pull/75 . It is a more simple version of #133 which should unblock the feature while `java.level=11` is not fully supported. So you still build plugins which are formally Java 8 compliant (source/target), but you can require Java 11 due to whatever reason.

* By default, injects versions like `1.8` or `1.7`
* Can be overridden to produce `11` for Java 11. Example: https://github.com/jenkinsci/label-verifier-plugin/pull/4 and https://github.com/jenkinsci/workflow-support-plugin/pull/82 

Consumer of the pull request: https://github.com/jenkins-infra/update-center2/pull/253

@jenkinsci/java11-support 
