### PR TITLE
Removing SUREFIRE-1588 workaround now that jdk.net.URLClassPath.disableClassPathURLCheck=true is the default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <!-- disableClassPathURLCheck is SUREFIRE-1588 workaround; too late for systemProperties: -->
-    <argLine>-Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+    <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
     <jenkins.version>2.60.1</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>


### PR DESCRIPTION
Cleans up #131. [Discussion](https://issues.apache.org/jira/browse/SUREFIRE-1588?focusedCommentId=16704836&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16704836)