### PR TITLE
Update to extra-enforcer-rules with JDK 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -583,7 +583,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-4</version>
+            <version>1.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
cc @jenkinsci/java11-support 

Full diff of the updated dependency: https://github.com/mojohaus/extra-enforcer-rules/compare/extra-enforcer-rules-1.0-beta-4...extra-enforcer-rules-1.1

:heavy_check_mark: Tested successfully in real conditions on the git-plugin. in https://github.com/jenkinsci/git-plugin/pull/639