### PR TITLE
Update frontend-maven-plugin from 1.4 to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <node.version>4.0.0</node.version>
     <npm.version>2.13.1</npm.version>
     <yarn.version>0.23.0</yarn.version>
-    <frontend-version>1.4</frontend-version>
+    <frontend-version>1.6</frontend-version>
     <skip.node.tests /> <!-- changed by -DskipTests, if specified - see profile -->
     <skip.node.lint /> <!-- changed by -DskipLint, if specified - see profile -->
     <npm.loglevel /> <!-- may use e.g. -\-silent (without backslash) -->


### PR DESCRIPTION
Version upgrade of the `frontend-maven-plugin`.

I believe we can safely do this globally given Blue Ocean already updated to this version a year ago: https://github.com/jenkinsci/blueocean-plugin/blob/master/pom.xml#L32 / https://github.com/jenkinsci/blueocean-plugin/pull/1464
