### PR TITLE
[JENKINS-20679] - Changelog: Clarify usage guidelines for the properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Release date: 2018-12-05
 
 * [JENKINS-20679](https://issues.jenkins-ci.org/browse/JENKINS-20679) -
 Plugin POM now produces `Minimum-Java-Version` entry in the plugin manifest
+  * `java.level` property value is used by default
+  * `plugin.minimumJavaVersion` property can be used to override the default value, e.g. for Java 11 experimental releases
+   ([JEP-211](https://github.com/jenkinsci/jep/tree/master/jep/211))
+  * **WARNING:** The override should not be used to define higher versions that the Jenkins core requirement
+   until [JENKINS-55048](https://issues.jenkins-ci.org/browse/JENKINS-55048) is released and widely adopted
 * [JENKINS-20679](https://issues.jenkins-ci.org/browse/JENKINS-20679) -
 Update to Maven HPI Plugin 3.0 
 ([changelog](https://github.com/jenkinsci/maven-hpi-plugin#30-2018-12-05))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Plugin POM now produces `Minimum-Java-Version` entry in the plugin manifest
   * `java.level` property value is used by default
   * `plugin.minimumJavaVersion` property can be used to override the default value, e.g. for Java 11 experimental releases
    ([JEP-211](https://github.com/jenkinsci/jep/tree/master/jep/211))
-  * **WARNING:** The override should not be used to define higher versions that the Jenkins core requirement
+  * **WARNING:** The override should not be used to define higher versions than the Jenkins core requirement
    until [JENKINS-55048](https://issues.jenkins-ci.org/browse/JENKINS-55048) is released and widely adopted
 * [JENKINS-20679](https://issues.jenkins-ci.org/browse/JENKINS-20679) -
 Update to Maven HPI Plugin 3.0 


### PR DESCRIPTION
Moves the policy from https://github.com/jenkinsci/jep/pull/221 to the changelog.
It is a temporary solution, ideally the behavior should be documented.


@jenkinsci/java11-support @daniel-beck will appreciate your opinions. Maybe it makes sense to keep `plugin.minimumJavaVersion` undocumented for now so that it's referenced only in developer guidelines for Java 11. But I rather prefer to be explicit