### PR TITLE
[JENKINS-55162] - Update to Maven JAR Plugin 3.1.1 to pick up the fix of MJAR-241

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
The fix should not do much harm. I see some related errors in PCT, but I am not 100% sure we are going to fix much here. There was a big update in https://github.com/batmat/plugin-pom/commit/b96483e0608923f227aa3999bf1e143f901be123 , so let's pick the latest version just in case

See https://issues.apache.org/jira/browse/MJAR-241