### PR TITLE
[JENKINS-55098] - Include Mockito and PowerMock to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,28 @@
         <version>1.2.17</version>
         <scope>provided</scope><!-- by log4j-over-slf4j -->
       </dependency>
+
+      <!-- Recommended versions of Mockito and PoweMock for build with Java 11 (JENKINS-55098) -->
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.23.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>2.0.0-RC.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito2</artifactId>
+        <version>2.0.0-RC.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>2.6</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
When building a Java 11 plugin with PowerMock tests, we get a bunch of warnings for PowerMock and Mockito. I propose to define it in Plugin Management of plugin POM

https://issues.jenkins-ci.org/browse/JENKINS-55098

Demo: https://github.com/jenkinsci/saml-plugin/pull/57

@jenkinsci/java11-support 