### PR TITLE
[JENKINS-55098] - Update to the proper objenesis version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,10 @@
         <scope>provided</scope><!-- by log4j-over-slf4j -->
       </dependency>
 
-      <!-- Recommended versions of Mockito and PoweMock for build with Java 11 (JENKINS-55098) -->
+      <!--
+      Recommended versions of Mockito and PowerMock for build with Java 11 (JENKINS-55098)
+      The versions require Java 8 as a minimum baseline, but they can be downgraded in plugins if needed.
+      -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
@@ -212,7 +215,7 @@
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>2.6</version>
+        <version>3.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
As @alecharp reported for one of his PCT tests for Java 11, objenesis 3.0.1 is actually used in PowerMock. Depending on the Mockito/PowerMock order, the enforcer was either passing or failing before. Should be fixed by this update 

https://issues.jenkins-ci.org/browse/JENKINS-55098

@jenkinsci/java11-support 
