### PR TITLE
[JENKINS-54631] - Update JaCoCo Plugin to 0.8.2 to pick up the Java 11 compat fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.1</version>
+          <version>0.8.2</version>
         </plugin>
         <plugin>
           <groupId>org.kohsuke.gmaven</groupId>


### PR DESCRIPTION
Picks up a compatibility fix for Java 11: https://github.com/jacoco/jacoco/issues/663

https://issues.jenkins-ci.org/browse/JENKINS-54631

@jenkinsci/java11-support 
