### PR TITLE
Upgrade the Surefire plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>plugin</artifactId>
-  <version>3.32</version>
+  <version>3.33-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Jenkins Plugin Parent POM</name>
@@ -38,7 +38,7 @@
   <scm>
     <connection>scm:git:ssh://git@github.com/jenkinsci/plugin-pom.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/plugin-pom.git</developerConnection>
-    <tag>plugin-3.32</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -673,7 +673,9 @@
         <extensions>true</extensions>
         <configuration>
           <showDeprecation>true</showDeprecation>
-          <contextPath>/jenkins</contextPath>
+          <webApp>
+              <contextPath>/jenkins</contextPath>
+          </webApp>
           <minimumJavaVersion>${plugin.minimumJavaVersion}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>

--- a/pom.xml
+++ b/pom.xml
@@ -348,11 +348,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1433,39 +1433,6 @@
       </build>
     </profile>
     <profile>
-      <id>jitpack</id>
-      <activation>
-        <property>
-          <name>env.JITPACK</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>attach-test-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-                <configuration>
-                  <skipSource>${no-test-jar}</skipSource>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>run-plugin-pom-its</id>
       <build>
         <plugins>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -27,7 +27,7 @@ under the License.
       <id>mrm-maven-plugin</id>
       <name>Mock Repository Manager</name>
       <url>@repository.proxy.url@</url>
-      <mirrorOf>*,!jitpack.io</mirrorOf>
+      <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
   <profiles>


### PR DESCRIPTION
Otherwise the SUREFIRE-1541 issue :
  SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
happens when building the amazon-ecs-plugin with
- Maven 3.5.2
- openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-1ubuntu0.18.04.1-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)