### PR TITLE
Removing jitpack profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1433,39 +1433,6 @@
       </build>
     </profile>
     <profile>
-      <id>jitpack</id>
-      <activation>
-        <property>
-          <name>env.JITPACK</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-source-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>attach-test-sources</id>
-                <goals>
-                  <goal>test-jar</goal>
-                </goals>
-                <configuration>
-                  <skipSource>${no-test-jar}</skipSource>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>run-plugin-pom-its</id>
       <build>
         <plugins>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -27,7 +27,7 @@ under the License.
       <id>mrm-maven-plugin</id>
       <name>Mock Repository Manager</name>
       <url>@repository.proxy.url@</url>
-      <mirrorOf>*,!jitpack.io</mirrorOf>
+      <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
   <profiles>


### PR DESCRIPTION
Given the adoption of [JEP-305](https://jenkins.io/jep/305) I think there is little need to include code to support [JitPack](https://jitpack.io/), which was only ever used temporarily in some since-merged PRs.