### PR TITLE
Fix warning about deprecated 'contextPath' parameter when using hpi:run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -673,7 +673,9 @@
         <extensions>true</extensions>
         <configuration>
           <showDeprecation>true</showDeprecation>
-          <contextPath>/jenkins</contextPath>
+          <webApp>
+              <contextPath>/jenkins</contextPath>
+          </webApp>
           <minimumJavaVersion>${plugin.minimumJavaVersion}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>


### PR DESCRIPTION
When running `mvn hpi:run` there was this warning:
> [WARNING] Please use `webApp/contextPath` configuration parameter in place of the deprecated `contextPath` parameter

See https://github.com/jenkinsci/maven-hpi-plugin/blob/maven-hpi-plugin-3.1/src/main/java/org/jenkinsci/maven/plugins/hpi/RunMojo.java#L226