### PR TITLE
[JENKINS-55456] Upgrade PowerMock version to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,12 +205,12 @@
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.0-RC.4</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito2</artifactId>
-        <version>2.0.0-RC.4</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.objenesis</groupId>


### PR DESCRIPTION
[JENKINS-55456](https://issues.jenkins-ci.org/browse/JENKINS-55456)

Upgrade `powermock` Junit and Mockito libraries from `2.0.0-RC.4` to `2.0.0`.