### PR TITLE
Upgrade of Surefire and Failsafe plugins to 3.0.0-M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,11 +348,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <!-- disableClassPathURLCheck is SUREFIRE-1588 workaround; too late for systemProperties: -->
-    <argLine>-Xmx768M -Djava.awt.headless=true -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+    <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
     <jenkins.version>2.60.1</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>


### PR DESCRIPTION
 -  [SUREFIRE-1541](https://issues.apache.org/jira/browse/SUREFIRE-1541) ,
 -  [SUREFIRE-1588](https://issues.apache.org/jira/browse/SUREFIRE-1588) ,
 -  [SUREFIRE-1608](https://issues.apache.org/jira/browse/SUREFIRE-1608) ,

SUREFIRE-1541's symptom was :
SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
happening when building the amazon-ecs-plugin with
- Maven 3.5.2
- openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-1ubuntu0.18.04.1-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)

We will be able to remove the SUREFIRE-1588 workaround as well