### PR TITLE
[JENKINS-55562, JENKINS-54949] - Update Maven HPI Plugin to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.44</jenkins-test-harness.version>
-    <hpi-plugin.version>3.1</hpi-plugin.version>
+    <hpi-plugin.version>3.2</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>


### PR DESCRIPTION
See https://github.com/jenkinsci/maven-hpi-plugin#32-2019-01-16 for the changelog. 

- [x] Add support of the `hpi.compatibleSinceVersion` property
- [x] Pickup the new self-include feature from @vtitov for the `custom-war` mojo (https://github.com/jenkinsci/maven-hpi-plugin/pull/86)

Once it is merged, we should update https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions to offer a better way there

@jenkinsci/java11-support @jglick 