### PR TITLE
Use powermock 2.0.0 instead of 2.0.0-RC.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,12 @@
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.0-RC.4</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>
         <artifactId>powermock-api-mockito2</artifactId>
-        <version>2.0.0-RC.4</version>
+        <version>2.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.objenesis</groupId>


### PR DESCRIPTION
Use the release 2.0.0 powermock for Java 8 and Java 11 compatibility.