### PR TITLE
Update findbugs annotations to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1u2</version>
       </dependency>
       <dependency>
         <groupId>net.jcip</groupId>


### PR DESCRIPTION
Because this version has source and javadocs on central (unfortuntly it depends & shades both of its dependencies - `jsr305` and `jcip-annotations` - but there is nothing correcter available)