### PR TITLE
[JENKINS-55885] Enable to run plugins with Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.46</jenkins-test-harness.version>
-    <hpi-plugin.version>3.2</hpi-plugin.version>
+    <hpi-plugin.version>3.3</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>


### PR DESCRIPTION
[JENKINS-55885](https://issues.jenkins-ci.org/browse/JENKINS-55885)

Update maven-hpi-plugin to be able to run hpi:run on plugins with Java 11.

@jenkinsci/java11-support 