### PR TITLE
Update core dependency to 2.138.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
     <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
-    <jenkins.version>2.60.1</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>


### PR DESCRIPTION
2.138.4 includes the [SECURITY-595 fix](https://jenkins.io/security/advisory/2018-12-05/#SECURITY-595) which might break some HTTP requests. Depending on it is a straightforward way to prevent this from happening without noticing.

Based on _January_ stats, 96k out of 145k users of LTS (66%) are on 2.138.1 or newer (i.e. could trivially update to this release, or have it already). 48k out of 87k weekly users (55%) are on 2.140 or newer. (2.139 wasn't properly released.)

So this looks like a reasonable baseline for any _new_ development.