### PR TITLE
[JENKINS-53788] - Add profile to workaround javadoc crash on JDK 11.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1490,5 +1490,28 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+    <!-- Workaround for https://bugs.openjdk.java.net/browse/JDK-8212233
+    TODO: likely just forbid 11.0.2 when 11.0.3 is out -->
+      <id>javadoc-crash-jdk-11.0.2</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>11.0.2</value>
+        </property>
+      </activation>
+      <build>
+          <pluginManagement>
+              <plugins>
+                  <plugin>
+                      <artifactId>maven-javadoc-plugin</artifactId>
+                      <configuration>
+                          <source>${java.level}</source>
+                      </configuration>
+                  </plugin>
+              </plugins>
+          </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Cf. for details https://bugs.openjdk.java.net/browse/JDK-8212233

Seen among many repos these days.
Known already to be blocking
* https://github.com/jenkinsci/workflow-job-plugin/pull/126
* https://github.com/jenkinsci/chucknorris-plugin/pull/19
...

cc @jenkinsci/java11-support 

Deployed as `3.40-20190308.114139-1`. Demonstration of the fix upcoming.