### PR TITLE
Ban TestNG dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,7 @@
                     <exclude>log4j:log4j:*:jar:runtime</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                    <!-- Jenkins Test Harness is based on JUnit. Adding TestNG dependency would disable some of its functionality. -->
                     <exclude>org.testng:testng</exclude>
                   </excludes>
                 </bannedDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,7 @@
                     <exclude>log4j:log4j:*:jar:runtime</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
                     <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                    <exclude>org.testng:testng</exclude>
                   </excludes>
                 </bannedDependencies>
                 <requireUpperBoundDeps>


### PR DESCRIPTION
As a big fan of TestNG, this was my default choice when selecting unit test framework for my Jenkins [plugin](https://github.com/jenkinsci/lambda-test-runner-plugin). As I wanted to add an end-to-end integration test and make use of Jenkins test harness provided (JenkinsRule and BuildWatcher), I configured my Maven project to use TestNG for unit tests and JUnit for ITs. I soon realised having two test frameworks in a single project is (slightly) overengineered and moved my unit tests to JUnit. It was a surprise for me when I noticed there were now 5 more tests (InjectedTest) - failing - which were not running before when I used TestNG for my unit tests. Having Maven run both TestNG and JUnit tests has always been problematic and required sometimes "not so nice" workarounds. There are many resources on this topic, including [this one](https://stackoverflow.com/questions/1232853/how-to-execute-junit-and-testng-tests-in-same-project-using-maven-surefire-plugi). My preference is to avoid such situation in first place, if possible.

Long story short, even if I don't have a single TestNG unit test in my test codebase, but define TestNG dependency in pom.xml, InjectedTest will not run. I'm opening this PR to ban TestNG dependency, so that people do not unknowingly disable InjectedTest.