### PR TITLE
stopbugs => spotbugs :-)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1024,7 +1024,7 @@
       </properties>
     </profile>
     <profile>
-      <id>stopbugs-exclusion-file</id>
+      <id>spotbugs-exclusion-file</id>
       <activation>
         <file>
           <exists>${basedir}/src/spotbugs/excludesFilter.xml</exists>


### PR DESCRIPTION
Well, overall, it definitely still made sense! :trollface: 

Followup of https://github.com/jenkinsci/plugin-pom/pull/128 where this was introduced.

I think we can just go and rename it without fearing some kind of backward compatibility issue, given this was only released in 3.36 parent pom, and I don't expect many people to rely on that profile name.


