### PR TITLE
Fix for JDK-8212233 is not a workaround, it should have been done anyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.1.0</version>
           <configuration>
+            <source>${java.level}</source>
             <quiet>true</quiet>
             <links>
               <link>http://javadoc.jenkins.io/</link>
@@ -1490,29 +1491,6 @@
             </executions>
           </plugin>
         </plugins>
-      </build>
-    </profile>
-    <profile>
-    <!-- Workaround for https://bugs.openjdk.java.net/browse/JDK-8212233
-    TODO: likely just forbid 11.0.2 when 11.0.3 is out -->
-      <id>javadoc-crash-jdk-11.0.2</id>
-      <activation>
-        <property>
-          <name>java.version</name>
-          <value>11.0.2</value>
-        </property>
-      </activation>
-      <build>
-          <pluginManagement>
-              <plugins>
-                  <plugin>
-                      <artifactId>maven-javadoc-plugin</artifactId>
-                      <configuration>
-                          <source>${java.level}</source>
-                      </configuration>
-                  </plugin>
-              </plugins>
-          </pluginManagement>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
As per https://github.com/jenkinsci/plugin-pom/pull/173#discussion_r279916866. Despite [JDK-8219474](https://bugs.openjdk.java.net/browse/JDK-8219474) claiming some fix was backported to 11.0.3, it is still reproducible in the AdoptOpenJDK build at least:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:jar (attach-javadocs) on project workflow-durable-task-step: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR] …/jenkinsci/workflow-durable-task-step-plugin/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java:374: warning: no @throws for java.io.IOException
[ERROR]         public @CheckForNull FlowNode getNode() throws IOException, InterruptedException {
[ERROR]                                       ^
[ERROR] …/jenkinsci/workflow-durable-task-step-plugin/src/main/java/org/jenkinsci/plugins/workflow/support/steps/ExecutorStepExecution.java:374: warning: no @throws for java.lang.InterruptedException
[ERROR]         public @CheckForNull FlowNode getNode() throws IOException, InterruptedException {
[ERROR]                                       ^
[ERROR] 
[ERROR] Command line was: …/jdk-11.0.3+7/bin/javadoc @options @packages
```