### PR TITLE
[JENKINS-58028] - Switch from gmaven to gmavenplus + Remove gmaven from `dependencyManagement`, gmavenplus should be used instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -753,6 +753,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <!-- gmavenplus generates into generated-sources/test by default. gmaven generated into this directory. -->
+          <testStubsOutputDirectory>${project.build.directory}/generated-test-sources/groovy-stubs</testStubsOutputDirectory>
+        </configuration>
+
       </plugin>
       <plugin> <!-- https://stackoverflow.com/a/4086207/12916 -->
           <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -427,11 +427,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.gmaven</groupId>
-          <artifactId>gmaven-plugin</artifactId>
-          <version>1.5-jenkins-3</version>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.gmavenplus</groupId>
           <artifactId>gmavenplus-plugin</artifactId>
           <version>1.7.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -747,6 +747,7 @@
           <execution>
             <id>test-in-groovy</id>
             <goals>
+              <goal>addTestSources</goal>
               <goal>generateTestStubs</goal>
               <goal>compileTests</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,11 @@
           <version>1.5-jenkins-3</version>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.7.1</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.0.0</version>
@@ -736,24 +741,17 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
         <executions>
           <execution>
             <id>test-in-groovy</id>
             <goals>
               <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
+              <goal>compileTests</goal>
             </goals>
           </execution>
         </executions>
-        <dependencies>
-          <dependency>
-            <groupId>ant</groupId>
-            <artifactId>ant</artifactId>
-            <version>1.6.5</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin> <!-- https://stackoverflow.com/a/4086207/12916 -->
           <artifactId>maven-antrun-plugin</artifactId>
@@ -983,11 +981,11 @@
                         </pluginExecution>
                         <pluginExecution>
                           <pluginExecutionFilter>
-                            <groupId>org.codehaus.gmaven</groupId>
-                            <artifactId>gmaven-plugin</artifactId>
+                            <groupId>org.codehaus.gmavenplus</groupId>
+                            <artifactId>gmavenplus-plugin</artifactId>
                             <versionRange>[1.0,)</versionRange>
                             <goals>
-                              <goal>testCompile</goal>
+                              <goal>compileTests</goal>
                               <goal>generateTestStubs</goal>
                             </goals>
                           </pluginExecutionFilter>


### PR DESCRIPTION
(I should have made this as draft PR, doh.)

This change keeps the dependency management for gmaven but moves the test compile and stub generation to gmavenplus.

Still a work-in-progress.  This will let us try out the change various plugin builds

pipeline-model-definition made this change recently in order to get java11 build working with minimal disruption.

[JENKINS-58028](https://issues.jenkins-ci.org/browse/JENKINS-58028)

@jenkinsci/java11-support