### PR TITLE
Removing support for jenkins-{core,war}.version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,6 @@
     <arguments> </arguments>
     <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
     <jenkins.version>2.138.4</jenkins.version>
-    <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
-    <jenkins-core.version>${jenkins.version}</jenkins-core.version>
-    <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.50</jenkins-test-harness.version>
     <hpi-plugin.version>3.5</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
@@ -124,12 +121,12 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
-        <version>${jenkins-core.version}</version>
+        <version>${jenkins.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-war</artifactId>
-        <version>${jenkins-war.version}</version>
+        <version>${jenkins.version}</version>
         <type>executable-war</type>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
These used to be required to support timestamped snapshots, as [described here](https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc#timestamped-snapshot-issues). But this is no longer necessary as of https://github.com/jenkinsci/jenkins/pull/3394 in Jenkins 2.120, so we might as well clean up this bit of complexity and assume that `jenkins.version` is either a release version (possibly “incremental”), or `*-SNAPSHOT` for local builds.