### PR TITLE
Exclude commons-lang3 and joda-time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,9 @@
                     <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
                     <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
+                    <!-- Makes no sense to check when Jenkins core version is being used runtime -->
+                    <exclude>org.apache.commons:commons-lang3</exclude>
+                    <exclude>joda-time:joda-time</exclude>
                   </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:
                   <plugin>


### PR DESCRIPTION
as the version used in coming from Jenkins Core runtime
https://github.com/jenkinsci/configuration-as-code-plugin/pull/977#discussion_r310901254

cc @oleg-nenashev 