### PR TITLE
Use "provided" scope for slf4j-api dependency (instead of `compile`)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4jVersion}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
       <!-- mark the API as optional so it is not packaged in the HPI but available during compile -->
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
While "provided" makes no difference to maven in presence of "optional", it would reassure plugin writers that they too can depend on "provided" slf4j-api and rely on it being present on Jenkins.