### PR TITLE
Add `scm.url` property to enable Plugin POM changelog visualization in Dependabot pull requests for plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
   <scm>
     <connection>scm:git:ssh://git@github.com/jenkinsci/plugin-pom.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/plugin-pom.git</developerConnection>
+    <url>https://github.com/jenkinsci/plugin-pom</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
See the discovery by @halkeye in https://groups.google.com/forum/#!topic/jenkinsci-dev/fFe3JDvvWDA 
