### PR TITLE
Improve maven-antrun-plugin configuration to show names of the executed targets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,9 +767,9 @@
                   <id>createTempDir</id>
                   <phase>generate-test-resources</phase>
                   <configuration>
-                      <tasks>
+                      <target>
                           <mkdir dir="${surefireTempDir}" />
-                      </tasks>
+                      </target>
                   </configuration>
                   <goals>
                       <goal>run</goal>
@@ -897,9 +897,9 @@
                   <goal>run</goal>
                 </goals>
                 <configuration>
-                  <tasks>
+                  <target>
                     <echo>WARNING: Plugin POM defines java.level=${java.level} which is deprecated in the current Plugin POM version. See https://github.com/jenkinsci/plugin-pom/blob/master/README.md#java-support</echo>
-                  </tasks>
+                  </target>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,10 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -891,16 +891,16 @@
             <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
-                <phase>initialize</phase>
                 <id>warn-deprecated-java.level</id>
-                <goals>
-                  <goal>run</goal>
-                </goals>
+                <phase>initialize</phase>
                 <configuration>
                   <target>
                     <echo>WARNING: Plugin POM defines java.level=${java.level} which is deprecated in the current Plugin POM version. See https://github.com/jenkinsci/plugin-pom/blob/master/README.md#java-support</echo>
                   </target>
                 </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
The output using a newer Ant is a bit more verbose, now showing the name of the target.

**old**
```
[INFO] --- maven-antrun-plugin:1.3:run (createTempDir) @ plugin ---
[INFO] Executing tasks
    [mkdir] Created dir: ***/plugin-pom/target/tmp
[INFO] Executed tasks
```

**new**
```
[INFO] --- maven-antrun-plugin:1.8:run (createTempDir) @ plugin ---
[INFO] Executing tasks

main:
    [mkdir] Created dir: ***/plugin-pom/target/tmp
[INFO] Executed tasks
```

It could therefore also be an option to just define version 1.3 and don't perform the `<tasks>` to `<target>` change.