### PR TITLE
Optimize the Maven Surefire JVM to speedup tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <argLine>-Xmx768M -Djava.awt.headless=true</argLine>
+    <argLine>-Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
     <jenkins.version>2.138.4</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>


### PR DESCRIPTION
given we are forking the JVM for all the tests local testing (with several plugins) has shown that we can be much faster if we do not try and do expensive JIT compilation.
Also set the initial memory to the same as the maximum as this helps too.

This will not work if the JVM does not recognise the flags (they are available in hotspot in JDK7+) but other JVMs (j9?) are unknown about.  that said the magority of plugin developers most likely use a hotspot based JVM and this is what we use in ci.jenkins.ci so I would recommend this and then let plugins whose authors build on something else adjust as nescessary.

