### PR TITLE
[JENKINS-60130] Remove powermock and mockito.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,31 +196,6 @@
         <version>1.2.17</version>
         <scope>provided</scope><!-- by log4j-over-slf4j -->
       </dependency>
-
-      <!--
-      Recommended versions of Mockito and PowerMock for build with Java 11 (JENKINS-55098)
-      The versions require Java 8 as a minimum baseline, but they can be downgraded in plugins if needed.
-      -->
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>3.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>2.0.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito2</artifactId>
-        <version>2.0.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.objenesis</groupId>
-        <artifactId>objenesis</artifactId>
-        <version>3.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
[JENKINS-60130](https://issues.jenkins-ci.org/browse/JENKINS-60130) The versions specified do not work together (depenadbot 🔫)
The powermock version is tied to a mockito version.
if a project want to use mocking let them choose what to do and do not
manage it for them.  Users of mocking frameworks should know much better
their requirements than the plugin-pom