### PR TITLE
Add phase to animal-sniffer to fix mvn test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,6 +669,7 @@
               <goal>check</goal>
             </goals>
             <id>check</id>
+            <phase>test</phase>
           </execution>
         </executions>
         <configuration>


### PR DESCRIPTION
Without this change I couldn't run `mvn test` in the https://github.com/jenkinsci/configuration-as-code-plugin

The error was:
```
animal-sniffer-maven-plugin:1.17:check: java.lang.NoSuchMethodError: java.nio.CharBuffer.position(I)Ljava/nio/CharBuffer;
```

the documentation says to use `test` https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/usage.html

cc @oleg-nenashev @sladyn98 @casz 