### PR TITLE
[JENKINS-60474] streamline the pom and support the jenkins-bom

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -31,7 +31,6 @@ Then you can just replace the Plugin POM version in your downstream PRs by this 
 ### Managing release notes
 
 * Changelog drafts are automatically by link:https://github.com/toolmantim/release-drafter[Release Drafter]
-* See the documentation about Jenkins Release Drafter configuration link:https://github.com/jenkinsci/.github/blob/master/docs/release-drafter.adoc[here]
 * When merging pull requests...
 ** Make sure to modify pull request titles to make them user-friendly
 ** Set proper labels so the changelog is categorized

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -31,6 +31,7 @@ Then you can just replace the Plugin POM version in your downstream PRs by this 
 ### Managing release notes
 
 * Changelog drafts are automatically by link:https://github.com/toolmantim/release-drafter[Release Drafter]
+** See the documentation about Jenkins Release Drafter configuration link:https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc[here]
 * When merging pull requests...
 ** Make sure to modify pull request titles to make them user-friendly
 ** Set proper labels so the changelog is categorized

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -13,7 +13,7 @@ For major changes we usually expect a reference implementation to be provided in
 
 To run and build the repository with integration tests, you can execute
 
-    mvn -Prun-plugin-pom-its clean verify
+    mvn clean verify
 
 ## Building and using snapshots
 
@@ -21,8 +21,8 @@ Snapshots might be needed to provide reference implementations for Plugin POM pa
 If you are a plugin maintainer with account on Jenkins artifactory,
 you can deploy a Plugin POM snapshot using this command:
 
-  mvn clean deploy
-  
+    mvn clean deploy
+
 Once the snapshot is deployed, you will see a timestamped snapshot version in Maven console output.
 Then you can just replace the Plugin POM version in your downstream PRs by this version so that you can demonstrate the build on ci.jenkins.io
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node('maven') {
         // TODO Azure mirror
         ansiColor('xterm') {
             withEnv(['MAVEN_OPTS=-Djansi.force=true']) {
-                sh 'mvn -B -Dstyle.color=always -ntp -Prun-plugin-pom-its clean verify'
+                sh 'mvn -B -Dstyle.color=always -ntp clean verify'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ See [Incrementals](https://github.com/jenkinsci/incrementals-tools) for details.
 To run JMH benchmarks from JUnit tests, you must run you must activate the `benchmark`
 profile. For example:
 ```bash
-mvn -Dbenchmark test
+mvn -P jmh-benchmark test
 ```
-When the `benchmark` property is set, no tests apart from JMH benchmarks will be run.
+When the `jmh-benchmark` profile is enabled, no tests apart from JMH benchmarks will be run.
 The names of the classes containing the benchmark runners should either begin with or
 end with the word `Benchmark`. For example, `FooBenchmark` and `BenchmarkFoo` will
 be detected when using `-Dbenchmark`, however, `FooBar` will be ignored.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This new parent POM is decoupled from the core Jenkins project, both from the Maven and repository perspectives.
 
+Since version 4.0 the plugin pom supports Jenkins 2.200 and higher and a select few older LTS lines (TBD)
+ 
 The main changes are:
 * Reduced number of overridable properties. All references (e.g. dependencies and plugin versions) not
 thought to be overridden are no longer based on properties. The main remaining overridable properties are:
@@ -15,12 +17,11 @@ thought to be overridden are no longer based on properties. The main remaining o
      See [Java Support](#java-support) for more info.
   * `jenkins-test-harness.version`: The [JTH version](https://github.com/jenkinsci/jenkins-test-harness/releases) used to test plugin.
   Uses split test-harness (see [JENKINS-32478](https://issues.jenkins-ci.org/browse/JENKINS-32478)).
-  If the required Jenkins version is 1.580.1 or higher, JTH 2.1+ is recommended.
   * `hpi-plugin.version`: The HPI Maven Plugin version used by the plugin.
   (Generally you should not set this to a version _lower_ than that specified in the parent POM.)
   * `stapler-plugin.version`: The Stapler Maven plugin version required by the plugin.
   * `java.level.test`: The Java version to use to build the plugin tests.
-  * In order to make their versions the same as the used core version, `slf4jVersion`, `node.version` and `npm.version`
+  * In order to make their versions the same as the used core version, `node.version` and `npm.version`
   properties are provided.
 * Tests are skipped during the `perform` phase of a release (can be overridden by setting `release.skipTests` to false).
 * Javadoc has been set to _quiet_ by default in 2.20+, which means it will only log errors and warnings. 
@@ -60,27 +61,9 @@ If you had a `jar:test-jar` execution, delete it and add to `properties`:
 
 The plugin POM is designed for plugin builds with JDK 8 or above,
 but target `java.level` for a plugin may differ from a JDK version used for the build.
-Starting from Plugin POM `3.44`, support of Java 7 targets in Plugin POM is deprecated,
-`java.level=8` and `jenkins.version>2.59` are expected to be used for most plugins.
+Starting from Plugin POM `3.44`, support of Java 7 targets in Plugin POM is deprecated and has been removed in `4.0`,
+`java.level=8` and `jenkins.version>2.204.1` are expected to be used for most plugins.
 
-### Using deprecated Java targets
-
-If recent plugin POM versions are required for a plugin with older baselines,
-a developer can use dependency version system properties to downgrade components incompatible with Java 7.
-
-Example:
-
-```xml
-    <properties>
-        <jenkins.version>2.32.3</jenkins.version>
-        <java.level>7</java.level>
-        <!-- Animal Sniffer Annotations 1.18 is not compatible with Java 7 anymore -->
-        <animal.sniffer.version>1.17</animal.sniffer.version>
-    </properties>
-```
-
-Such mode is no longer tested in the repository,
-and the list of incompatible dependencies will expand without further notice in new releases.
 
 ## Incrementals
 
@@ -213,13 +196,7 @@ By default, the setup wizard (Jenkins >= 2.0) is skipped when using `hpi:run`. I
 ## Jenkins Core BOM
 
 Since version 2.195, Jenkins provides a [Maven Bill Of Materials (BOM)](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)
-that centrally defines versions of various libraries used by Jenkins Core.
-The default behaviour of `plugin-pom` is to _not_ use the BOM, but when jenkins.version>=2.195 (and plugin-pom>=3.54) you can switch on Jenkins BOM support by setting the Maven property `use-jenkins-bom`.
-For example:
-
-`mvn -Djenkins.version=2.195 -Duse-jenkins-bom package`
-
-This will import the BOM for Jenkins 2.195
+that centrally defines versions of various libraries used by Jenkins Core and should make it easier to update to newer Jenkins Core versions
 
 For more information, see the [Dependency Management](https://jenkins.io/doc/developer/plugin-development/dependency-management/) section of the
 [plugin development guide](https://jenkins.io/doc/developer/plugin-development/).

--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,10 @@
                     <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>
                 </requireUpperBoundDeps>
+                <requireReleaseDeps>
+                  <message>No Snapshots Allowed For Release Versions</message>
+                  <onlyWhenRelease>true</onlyWhenRelease>
+                </requireReleaseDeps>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -355,11 +355,6 @@
         <plugin>
           <artifactId>maven-source-plugin</artifactId>
           <version>3.2.0</version>
-          <configuration>
-            <excludes>
-              <exclude>InjectedTest.java</exclude>
-            </excludes>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-war-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,8 @@
                 <requireReleaseDeps>
                   <message>No SNAPSHOT versions are allowed for releases</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
+                  <!--  whilst we generally want this this allows for easier testing of the plugin-pom in incrementals -->
+                  <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
                 </requireReleaseDeps>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,6 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit-dep</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -558,8 +558,23 @@
                     <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>
                 </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>no-snapshots-in-release</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <!-- 
+                  this causes fails the incrementals IT to fail as the parent is a snapshot and the incremental is a release
+                  so this is a separate execution so that it can be skipped in that specific IT
+                  -->
                 <requireReleaseDeps>
-                  <message>No Snapshots Allowed For Release Versions</message>
+                  <message>No SNAPSHOT versions are allowed for releases</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
                 </requireReleaseDeps>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -1633,5 +1633,18 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!--  a profile that disables as much testing as possible testing whilst still producing the artifacts -->
+      <id>quick-build</id>
+      <properties>
+        <!-- we can not use maven.test.skip because we may be producing a test jar -->
+        <skipTests>true</skipTests>
+        <spotbugs.skip>true</spotbugs.skip>
+        <enforcer.skip>true</enforcer.skip>
+        <access-modifier-checker.skip>true</access-modifier-checker.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1402,11 +1402,6 @@
     <!-- Profile to run benchmarks when the `benchmark` property is set -->
     <profile>
       <id>jmh-benchmark</id>
-      <activation>
-        <property>
-          <name>benchmark</name>
-        </property>
-      </activation>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -188,13 +188,14 @@
       <artifactId>jenkins-core</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- dependencies needed for testing -->
+    <!-- jenkins war needed for testing -->
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
       <type>war</type>
       <scope>test</scope>
     </dependency>
+
     <!-- dependencies provided by virtue of running in Jenkins -->
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -225,6 +226,7 @@
     </dependency>
     <dependency>
       <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
+      <!-- TODO this would be better as a managed version of [0] -->
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1432,6 +1432,7 @@
         <enforcer.skip>true</enforcer.skip>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <animal.sniffer.skip>true</animal.sniffer.skip>
+        <invoker.skip>true</invoker.skip>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
 
-    <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
@@ -732,6 +731,26 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <!-- SUREFIRE-1226 workaround -->
+          <trimStackTrace>false</trimStackTrace>
+          <systemProperties>
+            <property>
+              <name>hudson.udp</name>
+              <value>-1</value>
+            </property>
+            <property>
+              <name>java.io.tmpdir</name>
+              <value>${surefireTempDir}</value>
+            </property>
+          </systemProperties>
+          <runOrder>alphabetical</runOrder>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <!-- SUREFIRE-1226 workaround -->
+          <trimStackTrace>false</trimStackTrace>
           <systemProperties>
             <property>
               <name>hudson.udp</name>
@@ -1085,7 +1104,6 @@
               </execution>
               <execution>
                 <id>report</id>
-                <phase>prepare-package</phase>
                 <goals>
                   <goal>report</goal>
                 </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,6 @@
     <skip.node.lint /> <!-- changed by -DskipLint, if specified - see profile -->
     <npm.loglevel /> <!-- may use e.g. -\-silent (without backslash) -->
 
-    <!-- For jgit-scm-provider profile -->
-    <git.provider>git</git.provider>
-    <maven-scm.version>1.11.2</maven-scm.version>
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
 
@@ -1291,50 +1288,6 @@
                 </fileset>
               </filesets>
             </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jgit-scm-provider</id>
-      <activation>
-        <property>
-          <name>git.provider</name>
-          <value>jgit</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-release-plugin</artifactId>
-            <configuration>
-              <providerImplementations>
-                <git>${git.provider}</git>
-              </providerImplementations>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-provider-jgit</artifactId>
-                <version>${maven-scm.version}</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-          <plugin>
-            <artifactId>maven-scm-plugin</artifactId>
-            <version>${maven-scm.version}</version>
-            <configuration>
-              <providerImplementations>
-                <git>${git.provider}</git>
-              </providerImplementations>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-provider-jgit</artifactId>
-                <version>${maven-scm.version}</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1012,17 +1012,6 @@
       </properties>
     </profile>
     <profile>
-      <id>rerunFailingTests</id>
-      <activation>
-        <property>
-          <name>!test</name>
-        </property>
-      </activation>
-      <properties>
-        <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
-      </properties>
-    </profile>
-    <profile>
       <id>skip-node-tests</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -64,19 +64,12 @@
     <concurrency>1</concurrency> <!-- DEPRECATED use forkCount -->
     <forkCount>${concurrency}</forkCount> <!-- may use e.g. 2C for 2 × (number of cores) -->
     <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
-    <!-- Deprecated findbugs. -->
-    <findbugs.failOnError>true</findbugs.failOnError>
-    <findbugs.threshold>Medium</findbugs.threshold>
-    <findbugs.effort>default</findbugs.effort>
-    <!-- Whether the build should fail if SpotBugs finds any error. -->
-    <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
-    <spotbugs.failOnError>${findbugs.failOnError}</spotbugs.failOnError>
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
-    <spotbugs.threshold>${findbugs.threshold}</spotbugs.threshold>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
     <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->
-    <spotbugs.effort>${findbugs.effort}</spotbugs.effort>
+    <spotbugs.effort>Default</spotbugs.effort>
     
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
@@ -1134,18 +1127,6 @@
       </activation>
       <properties>
         <surefire.rerunFailingTestsCount>4</surefire.rerunFailingTestsCount>
-      </properties>
-    </profile>
-    <profile>
-      <id>skip-spotbugs-with-tests</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <properties>
-        <spotbugs.skip>true</spotbugs.skip>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1054,7 +1054,6 @@
       <id>jenkins-release</id>
       <properties>
         <skipTests>${release.skipTests}</skipTests>
-        <findbugs.skip>${release.skipTests}</findbugs.skip>
         <spotbugs.skip>${release.skipTests}</spotbugs.skip>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
+
     <jenkins-test-harness.version>2.56</jenkins-test-harness.version>
     <hpi-plugin.version>3.11</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
@@ -82,6 +83,7 @@
     <skip.node.tests /> <!-- changed by -DskipTests, if specified - see profile -->
     <skip.node.lint /> <!-- changed by -DskipLint, if specified - see profile -->
     <npm.loglevel /> <!-- may use e.g. -\-silent (without backslash) -->
+
     <!-- For jgit-scm-provider profile -->
     <git.provider>git</git.provider>
     <maven-scm.version>1.11.2</maven-scm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,11 @@
             <updateNonincremental>false</updateNonincremental>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>3.1.12.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -576,7 +581,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.12.2</version>
         <configuration>
           <failOnError>${spotbugs.failOnError}</failOnError>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <argLine>-Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
 
     <jenkins.version>2.204</jenkins.version>
-    <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
+    <!-- Should only need to override these if using timestamped snapshots https://issues.apache.org/jira/browse/MNG-6274 (but better to use Incrementals instead)  -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>plugin</artifactId>
-  <version>3.55-SNAPSHOT</version>
+  <version>4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Jenkins Plugin Parent POM</name>
@@ -49,10 +49,11 @@
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
     <argLine>-Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.204</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
+    <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
     <jenkins-test-harness.version>2.56</jenkins-test-harness.version>
     <hpi-plugin.version>3.11</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
@@ -104,6 +105,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-bom</artifactId>
+        <version>${jenkins-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
@@ -194,12 +202,7 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- dependencies provided by virtue of running in Jenkins -->
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
+    <!--  Jenkins core dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
@@ -212,6 +215,53 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+    <!-- dependencies provided by virtue of running in Jenkins -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- static analysis -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- for JRE requirement check annotation -->
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>animal-sniffer-annotations</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional><!-- no need to have this at runtime -->
+    </dependency>
+    <dependency>
+      <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- provided by Jenkins core -->
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>annotation-indexer</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
@@ -814,201 +864,6 @@
   </distributionManagement>
 
   <profiles>
-    <profile>
-      <!--
-       The 'no-jenkins-bom' profile captures the properties & dependencies when _not_ using the Jenkins BOM:
-        https://github.com/jenkinsci/jenkins/blob/master/bom/pom.xml
-       When the BOM is not being used, this profile is adding back the <dependencyManagement /> entries that were
-       moved to the BOM.
-       The profile is enabled by default; if you _are_ using the Jenkins BOM then disable this profile by defining the
-       'use-jenkins-bom' system property.
-      -->
-      <id>no-jenkins-bom</id>
-      <activation>
-        <property>
-          <name>!use-jenkins-bom</name>
-        </property>
-      </activation>
-      <properties>
-        <slf4jVersion>1.7.25</slf4jVersion>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>3.1.12</version>
-          </dependency>
-          <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
-          </dependency>
-          <!-- mark logging dependencies as provided by war -->
-          <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope><!-- by jcl-over-slf4j -->
-          </dependency>
-          <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>provided</scope><!-- by log4j-over-slf4j -->
-          </dependency>
-          <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4jVersion}</version>
-            <!-- TODO: should this optional be in dependencyManagement too??? -->
-            <scope>provided</scope>
-            <!-- mark the API as optional so it is not packaged in the HPI but available during compile -->
-            <optional>true</optional>
-          </dependency>
-          <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>test</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>test</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>test</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-      <dependencies>
-          <!-- static analysis -->
-        <dependency>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>net.jcip</groupId>
-          <artifactId>jcip-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <!-- for JRE requirement check annotation -->
-        <dependency>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional><!-- no need to have this at runtime -->
-        </dependency>
-        <!-- make slf4j bindings to java.util.logging available during tests -->
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>log4j-over-slf4j</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>jcl-over-slf4j</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>access-modifier-annotation</artifactId>
-          <version>${access-modifier-annotation.version}</version>
-          <scope>provided</scope>
-          <exclusions> <!-- provided by Jenkins core -->
-            <exclusion>
-              <groupId>org.jenkins-ci</groupId>
-              <artifactId>annotation-indexer</artifactId>
-              </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency> <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <!--
-       This profile can be activated by plugins that _are_ using the Jenkins BOM, by setting the system property
-       'use-jenkins-bom'. A convenient way to do this is by adding the command line parameter '-Duse-jenkins-bom'
-       'in ${maven.projectBasedir}/.mvn/maven.config'.
-       This profile imports the jenkins BOM at ${jenkins.version} to properly align dependencies.
-      -->
-    <profile>
-      <id>use-jenkins-bom</id>
-      <activation>
-        <property>
-          <name>use-jenkins-bom</name>
-        </property>
-      </activation>
-      <properties>
-        <jenkins.version>2.195</jenkins.version>
-      </properties>
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-bom</artifactId>
-            <version>${jenkins.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-      <dependencies>
-        <!-- static analysis -->
-        <dependency>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <dependency>
-          <groupId>net.jcip</groupId>
-          <artifactId>jcip-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional>
-        </dependency>
-        <!-- for JRE requirement check annotation -->
-        <dependency>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-          <scope>provided</scope>
-          <optional>true</optional><!-- no need to have this at runtime -->
-        </dependency>
-        <dependency> <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-          <scope>provided</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>access-modifier-annotation</artifactId>
-          <version>${access-modifier-annotation.version}</version>
-          <scope>provided</scope>
-          <exclusions> <!-- provided by Jenkins core -->
-            <exclusion>
-              <groupId>org.jenkins-ci</groupId>
-              <artifactId>annotation-indexer</artifactId>
-              </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
-    </profile>
     <profile>
       <id>uninherited-java.level</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
-    <concurrency>1</concurrency> <!-- DEPRECATED use forkCount -->
-    <forkCount>${concurrency}</forkCount> <!-- may use e.g. 2C for 2 × (number of cores) -->
+
     <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1226 workaround -->
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>plugin</artifactId>
-  <version>4.0-SNAPSHOT</version>
+  <version>4.0-beta-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Jenkins Plugin Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>plugin</artifactId>
-  <version>4.0-beta-SNAPSHOT</version>
+  <version>4.0-beta-1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Jenkins Plugin Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
     <argLine>-Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
+
     <jenkins.version>2.204</jenkins.version>
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
@@ -58,7 +59,6 @@
     <hpi-plugin.version>3.11</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
-    <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>
     <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
     <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
     <java.level.test>${java.level}</java.level.test>
@@ -642,7 +642,7 @@
           <webApp>
               <contextPath>/jenkins</contextPath>
           </webApp>
-          <minimumJavaVersion>${plugin.minimumJavaVersion}</minimumJavaVersion>
+          <minimumJavaVersion>1.${java.level}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
           </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-war</artifactId>
         <version>${jenkins-war.version}</version>
-        <type>executable-war</type>
+        <type>war</type>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <type>executable-war</type>
+      <type>war</type>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-war</artifactId>
         <version>${jenkins-war.version}</version>
-        <type>war</type>
+        <type>executable-war</type>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <type>war</type>
+      <type>executable-war</type>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -745,6 +745,52 @@
           </execution>
         </executions>
       </plugin>
+
+      <!--  the following 2 plugins are for integration tests of plugin-pom only -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>mrm-maven-plugin</artifactId>
+        <version>1.2.0</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <goals>
+              <goal>start</goal>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <propertyName>repository.proxy.url</propertyName>
+              <repositories>
+                <proxyRepo />
+              </repositories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.2.1</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <streamLogs>true</streamLogs>
+              <showErrors>true</showErrors>
+              <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
+              <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <filterProperties>
+                <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+              </filterProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -1565,55 +1611,6 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>run-plugin-pom-its</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>mrm-maven-plugin</artifactId>
-            <version>1.2.0</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>start</goal>
-                  <goal>stop</goal>
-                </goals>
-                <configuration>
-                  <propertyName>repository.proxy.url</propertyName>
-                  <repositories>
-                    <proxyRepo />
-                  </repositories>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-invoker-plugin</artifactId>
-            <version>3.2.1</version>
-            <executions>
-              <execution>
-                <id>integration-test</id>
-                <goals>
-                  <goal>install</goal>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <streamLogs>true</streamLogs>
-                  <showErrors>true</showErrors>
-                  <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
-                  <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
-                  <settingsFile>src/it/settings.xml</settingsFile>
-                  <filterProperties>
-                    <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
-                  </filterProperties>
-                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -890,36 +890,6 @@
       </properties>
     </profile>
     <profile>
-      <id>deprecated-java.level-7</id>
-      <activation>
-        <property>
-          <name>java.level</name>
-          <value>7</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>warn-deprecated-java.level</id>
-                <phase>initialize</phase>
-                <configuration>
-                  <target>
-                    <echo>WARNING: Plugin POM defines java.level=${java.level} which is deprecated in the current Plugin POM version. See https://github.com/jenkinsci/plugin-pom/blob/master/README.md#java-support</echo>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>jenkins-release</id>
       <properties>
         <skipTests>${release.skipTests}</skipTests>

--- a/pom.xml
+++ b/pom.xml
@@ -150,24 +150,6 @@
       </dependency>
       <dependency>
         <groupId>org.codehaus.mojo.signature</groupId>
-        <artifactId>java15</artifactId>
-        <version>1.0</version>
-        <type>signature</type>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.mojo.signature</groupId>
-        <artifactId>java16</artifactId>
-        <version>1.1</version>
-        <type>signature</type>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.mojo.signature</groupId>
-        <artifactId>java17</artifactId>
-        <version>1.0</version>
-        <type>signature</type>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.mojo.signature</groupId>
         <artifactId>java18</artifactId>
         <version>1.0</version>
         <type>signature</type>

--- a/src/it/benchmark/invoker.properties
+++ b/src/it/benchmark/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=-Dstyle.color=always -ntp -Dbenchmark clean test
+invoker.goals=-P jmh-benchmark -Dstyle.color=always -ntp clean test

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <repositories>

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.107.1</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -17,6 +17,22 @@
         <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
     </properties>
+
+    <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <!-- this pom is a release in the IT - but the parent is a SNAPSHOT - so just disable this for testing purposes -->
+              <id>no-snapshots-in-release</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -18,21 +18,6 @@
         <java.level>8</java.level>
     </properties>
 
-    <build>
-      <plugins>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <!-- this pom is a release in the IT - but the parent is a SNAPSHOT - so just disable this for testing purposes -->
-              <id>no-snapshots-in-release</id>
-              <phase>none</phase>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <repositories>

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <repositories>

--- a/src/it/undefined-java-level/pom.xml
+++ b/src/it/undefined-java-level/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.32.3</jenkins.version>
+        <jenkins.version>2.204</jenkins.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
[JENKINS-60474](https://issues.jenkins-ci.org/browse/JENKINS-60474) Streamlines the plugin pom by removing support for some older settings as per https://groups.google.com/d/topic/jenkinsci-dev/tm3F_vgK5vA/discussion

I did not remove the frontend parts for now - I have kicked that can down the road. but there are some other areas that have been streamlined.

downstream PRs
* https://github.com/jenkinsci/m2release-plugin/pull/36
* https://github.com/jenkinsci/cloudbees-folder-plugin/pull/139

changelog suggestions

* [internal] always run the integration tests in this module
* libraries that are shipped with jenkins-core now have their dependency version unconditionally managed from the [`jenkins-bom`](https://github.com/jenkinsci/jenkins/blob/jenkins-2.204.1/bom/pom.xml).  With this change the libaries used will be correct for a given `jenkins.version` however this requires a version of Jenkins that was published with the bom (2.195 or higher), or has been explicitly published (see [here](https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-bom/) for a list of supported versions.  The `jenkins-bom` and `no-jenkins-bom` profiles have been removed
* `findbugs` properties have been removed, use the equivalent `spotbugs` property
* support for compiling plugins with java < 7 has been removed.  currently the only supported `java.level` is `8`
* `concurrency` property has been removed.  use the [`forkCount`](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#forkCount) surefire option directly from the command line (or pom)  (e.g. `mvn -DforkCount=4 verify`)
* support for the `jgit` provider of the release plugin has been removed.  the `git` executable is now required to be installed
* an extra enforcer rule has been added to prevent releases containing `SNAPSHOT` versions
*  the automatic re-running of failing tests has been removed.  if this is desired it should be set per project by configuring `surefire`'s [`rerunFailingTestsCount`](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#rerunFailingTestsCount) parameter
* jmh benchmarks are now run by activating the `jmh-benchmark` directly rather than via a property. (`mvn -P jmh-benchmark test`)
* skipping tests using `surefire'`s `skipTest` property no longer skips other mojos execution.  
* a `quick-build` profile has been introduced that disabled things not related to just producing the desired artifacts.  This is activated on the command line in the standard maven way (e.g.  `mvn -P quick-build package`)
