### PR TITLE
Change groupId to io.jenkins.pom to support Dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to use the new POM:
 * Change the parent POM of your plugin:
 ```xml
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
+    <groupId>io.jenkins.pom</groupId>
     <artifactId>plugin</artifactId>
     <version>3.43</version> <!-- or whatever the newest version available is -->
     <relativePath />
@@ -46,7 +46,7 @@ In order to use the new POM:
 * Override the needed properties, e.g.:
 ```xml
   <properties>
-    <jenkins.version>2.60.1</jenkins.version>
+    <jenkins.version>2.204.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.jenkins-ci.plugins</groupId>
+  <groupId>io.jenkins.pom</groupId>
   <artifactId>plugin</artifactId>
   <version>4.0-beta-1-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath />

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>

--- a/src/it/undefined-java-level/pom.xml
+++ b/src/it/undefined-java-level/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
+        <groupId>io.jenkins.pom</groupId>
         <artifactId>plugin</artifactId>
         <version>@project.version@</version>
         <relativePath/>


### PR DESCRIPTION
I am not sure it is a good idea taking all the tooling and documentation around Jenkins plugin POMs, but it is the only way to enable Dependabot for plugin POMs while disabling plugin updates. Here is a sample config which DOES NOT work according to my tests

```yaml
version: 1
update_configs:
- package_manager: "java:maven"
  directory: "/"
  update_schedule: "weekly"
  default_reviewers:
    - "oleg-nenashev"
    - "runzexia"
  ignored_updates:
    - match:
        dependency_name: "org.jenkins-ci.main:jenkins-core"
    - match:
        dependency_name: "org.jenkins-ci.plugins*"
    - match:
        dependency_name: "io.jenkins.plugins*"
  allowed_updates:
    - match:
        dependency_name: "org.jenkins-ci.plugins:plugin"
```