### PR TITLE
Add link to show all BOM versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This new parent POM is decoupled from the core Jenkins project, both from the Maven and repository perspectives.
 
-Since version 4.0 the plugin pom supports Jenkins 2.200 and higher and a select few older LTS lines (TBD)
+Since version 4.0 the plugin pom supports Jenkins 2.200 and higher and a select few older LTS lines ([full list](https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-bom/))
  
 The main changes are:
 * Reduced number of overridable properties. All references (e.g. dependencies and plugin versions) not


### PR DESCRIPTION
link to the repo so people can find the versions of Jenkins with a bom easier.
fortunately artifactory has some sensible ordering for versions in the index view (there was not an easy way I could find to link to a search result inside the main UI)