### PR TITLE
[JENKINS-60694] - Update Jenkins Test Harness to 2.60 with the hanging injected test fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
 
-    <jenkins-test-harness.version>2.59</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
 
     <hpi-plugin.version>3.11</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-60694

update to 2.60 of JTH [release notes](https://github.com/jenkinsci/jenkins-test-harness/releases/tag/jenkins-test-harness-2.60) to pick up fix for jetty hang in `InjectedTest` (and any other `HudsonTestCase`)