### PR TITLE
Plugin POM 3.x: Backport Jenkins Test Harness 2.61 and Maven HPI Plugin 3.12 updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,8 @@
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
     <jenkins-test-harness.version>2.61</jenkins-test-harness.version>
-    <hpi-plugin.version>3.11</hpi-plugin.version>
+
+    <hpi-plugin.version>3.12</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
     <plugin.minimumJavaVersion>1.${java.level}</plugin.minimumJavaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <!-- Should only need to override these if using timestamped snapshots (but better to use Incrementals instead): -->
     <jenkins-core.version>${jenkins.version}</jenkins-core.version>
     <jenkins-war.version>${jenkins.version}</jenkins-war.version>
-    <jenkins-test-harness.version>2.60</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.61</jenkins-test-harness.version>
     <hpi-plugin.version>3.11</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>4.13</version>
       </dependency>
       <!-- JTN tidy this up? -->
       <dependency> <!-- used in JTH and jenkins core > 2.x -->


### PR DESCRIPTION
Backports #290 and #288 , see the changelog links in these pull requests