### PR TITLE
do not run invoker during release:perform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -897,6 +897,7 @@
       <properties>
         <skipTests>${release.skipTests}</skipTests>
         <spotbugs.skip>${release.skipTests}</spotbugs.skip>
+        <invoker.skip>true</invoker.skip>
       </properties>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
       <properties>
         <skipTests>${release.skipTests}</skipTests>
         <spotbugs.skip>${release.skipTests}</spotbugs.skip>
-        <invoker.skip>true</invoker.skip>
+        <invoker.skip>${release.skipTests}</invoker.skip>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
@jglick points out we do not run tests during the release:perform phase so we may as well skip the invoker in that stage too.