### PR TITLE
Actually support PowerMock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target
 work
-*.class
+build.log
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -15,6 +15,13 @@ To run and build the repository with integration tests, you can execute
 
     mvn clean verify
 
+To run one IT:
+
+[source,bash]
+----
+mvn verify -Dinvoker.test=powermock
+----
+
 ## Building and using snapshots
 
 Snapshots might be needed to provide reference implementations for Plugin POM patches.

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
         <artifactId>objenesis</artifactId>
         <version>3.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/it/powermock/invoker.properties
+++ b/src/it/powermock/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-Dstyle.color=always -ntp clean install

--- a/src/it/powermock/pom.xml
+++ b/src/it/powermock/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>@project.version@</version>
+        <relativePath />
+    </parent>
+    <groupId>io.jenkins.plugins</groupId>
+    <artifactId>powermock</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>2.235.1</jenkins.version>
+        <java.level>8</java.level>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/it/powermock/src/main/resources/index.jelly
+++ b/src/it/powermock/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    irrelevant
+</div>

--- a/src/it/powermock/src/test/java/test/XTest.java
+++ b/src/it/powermock/src/test/java/test/XTest.java
@@ -1,0 +1,32 @@
+package test;
+
+import jenkins.model.Jenkins;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Jenkins.class)
+public class XTest {
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Before
+    public void setUp() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
+        PowerMockito.when(jenkins.getSystemMessage()).thenReturn("mocked");
+    }
+
+    @Test
+    public void smokes() {
+        assertEquals("mocked", Jenkins.get().getSystemMessage());
+    }
+
+}


### PR DESCRIPTION
#331 was actually necessary in order to pick up https://github.com/mockito/mockito/pull/1974 (see https://github.com/powermock/powermock/issues/1055), so this needs a release; and there was also a dependency tree conflict with Hamcrest. Noticed from some of the test failures in https://github.com/jenkinsci/github-oauth-plugin/pull/119.