### PR TITLE
Bump jenkins test harness to 2.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <jenkins.version>2.204</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
 
-    <jenkins-test-harness.version>2.65</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2.66</jenkins-test-harness.version>
 
     <hpi-plugin.version>3.15</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins-test-harness/releases/tag/jenkins-test-harness-2.66

<details>
<summary>Release notes</summary>

> ## 📦 Dependency updates
> 
> * Bump jenkins-test-harness-htmlunit from 2.36.0-1 to 3 (#232) @dependabot
> * Bump jetty.version from 9.4.30.v20200611 to 9.4.31.v20200723 (#231) @dependabot

</details>