### PR TITLE
Revert Surefire to 3.0.0-M4 to avoid SUREFIRE-1827

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,11 +295,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M4</version>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M4</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
Reverting #320 because it introduced [SUREFIRE-1827](https://issues.apache.org/jira/browse/SUREFIRE-1827) which is very bad for Jenkins functional tests: you see no output as the test is running, only whenever it completes (or times out).