### PR TITLE
Generate metadata for reflection on method parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,9 @@
     <scmTag>HEAD</scmTag>
     <!-- Where to put temporary files during test runs. -->
     <surefireTempDir>${project.build.directory}/tmp</surefireTempDir>
+
+    <!-- Generate metadata for reflection on method parameters -->
+    <maven.compiler.parameters>true</maven.compiler.parameters>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
See stapler/stapler#226 and [the Maven documentation](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#parameters). Once widely adopted, this would allow us to use reflection rather than ASM in Stapler for discovering method parameters. To test this change, I verified that a plugin was not able to access method parameters via reflection with the current plugin parent POM but was able to access them from a plugin parent POM with these changes. I also verified that plugins can opt out of this functionality if desired by setting `maven.compiler.parameters` to `false` in their `<properties>` section.