### PR TITLE
[JENKINS-50804] Pass `-P!consume-incrementals` during `release:perform`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -660,7 +660,7 @@
           <preparationGoals>clean install</preparationGoals>
           <goals>deploy</goals>
           <arguments>${arguments}</arguments>
-          <releaseProfiles>jenkins-release,${releaseProfiles}</releaseProfiles>
+          <releaseProfiles>jenkins-release,!consume-incrementals,${releaseProfiles}</releaseProfiles>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Akin to https://github.com/jenkins-infra/jenkins-maven-cd-action/issues/3 but for plugins which are using MRP, we do not wish to activate the `consume-incrementals` profile during the release phase because it might result in an incrementals-only artifact being included in a release version. The original conception of [JENKINS-50804](https://issues.jenkins.io/browse/JENKINS-50804) involved a new Enforcer rule active during releases that would block incremental dependencies, akin to snapshot dependencies which are already blocked, but this assumed that they could be detected via a pattern like `*-rc.*` which is not as easy as of JEP-229. Seems more straightforward to do this at the repository level.

Note that I am not exactly sure how to test this. I can verify that

```bash
mvn -P 'jenkins-release,!consume-incrementals, ' validate
```

fails as expected when run on a downstream PR that is consuming an upstream PR via incremental dep. The doc for `releaseProfiles` says only vaguely

> Comma separated profiles to enable on deployment, in addition to active profiles for project execution.

without specifying whether `!` syntax is legal, but the [implementation](https://github.com/apache/maven-release/blob/e8f77842fc3cf29d912fcdbb6525b409c971e44d/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractReleaseMojo.java#L159-L187) seems to just pass the string as is after `-P` without any attempt at splitting on `,` etc.