### PR TITLE
[JENKINS-66247] Do not override the version of `annotation-indexer` from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,11 +178,6 @@
         <artifactId>hamcrest-core</artifactId>
         <version>2.2</version>
       </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci</groupId>
-        <artifactId>annotation-indexer</artifactId>
-        <version>1.14</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>


### PR DESCRIPTION
#424 should not have overridden the version of this library. See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/443.

For now, just run ITs against a version of core containing https://github.com/jenkinsci/jenkins/pull/5208. The better fix will be to make `access-modifier-checker` capable of reading both the old and new index location.