### PR TITLE
[JENKINS-66247] Pick up more compatible `access-modifier-checker`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
 
-    <access-modifier-checker.version>1.22</access-modifier-checker.version>
+    <access-modifier-checker.version>1.23-SNAPSHOT</access-modifier-checker.version> <!-- TODO -->
     <animal.sniffer.version>1.20</animal.sniffer.version>
     <powermock.version>2.0.9</powermock.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
 
-    <access-modifier-checker.version>1.23-SNAPSHOT</access-modifier-checker.version> <!-- TODO https://github.com/jenkinsci/lib-access-modifier/pull/53 -->
+    <access-modifier-checker.version>1.23</access-modifier-checker.version>
     <animal.sniffer.version>1.20</animal.sniffer.version>
     <powermock.version>2.0.9</powermock.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
 
-    <access-modifier-checker.version>1.23-SNAPSHOT</access-modifier-checker.version> <!-- TODO -->
+    <access-modifier-checker.version>1.23-SNAPSHOT</access-modifier-checker.version> <!-- TODO https://github.com/jenkinsci/lib-access-modifier/pull/53 -->
     <animal.sniffer.version>1.20</animal.sniffer.version>
     <powermock.version>2.0.9</powermock.version>
 

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>
@@ -33,4 +33,13 @@
         <module>upstream</module>
         <module>downstream</module>
     </modules>
+    <dependencyManagement> <!-- TODO -->
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci</groupId>
+                <artifactId>annotation-indexer</artifactId>
+                <version>1.15-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -33,13 +33,4 @@
         <module>upstream</module>
         <module>downstream</module>
     </modules>
-    <dependencyManagement> <!-- TODO -->
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci</groupId>
-                <artifactId>annotation-indexer</artifactId>
-                <version>1.15-SNAPSHOT</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <jenkins.version>2.289.3</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
         <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
     </properties>


### PR DESCRIPTION
Test environment for https://github.com/jenkinsci/lib-access-modifier/pull/52, then switched to picking up https://github.com/jenkinsci/lib-access-modifier/pull/53. Amends #424 / #426.