### PR TITLE
Bogus errors about `@Restricted(NoExternalUse.class)` as in `localizer-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- To skip the wizard by default in hpi:run. It should not impact other goals. -->
     <hudson.Main.development>true</hudson.Main.development>
 
-    <access-modifier-checker.version>1.23</access-modifier-checker.version>
+    <access-modifier-checker.version>1.24</access-modifier-checker.version>
     <animal.sniffer.version>1.20</animal.sniffer.version>
     <powermock.version>2.0.9</powermock.version>
 

--- a/src/it/localizer/invoker.properties
+++ b/src/it/localizer/invoker.properties
@@ -1,0 +1,2 @@
+# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
+invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean verify

--- a/src/it/localizer/pom.xml
+++ b/src/it/localizer/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>@project.version@</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>localizer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>2.277.4</jenkins.version>
+        <java.level>8</java.level>
+        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+    </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/it/localizer/src/main/java/test/X.java
+++ b/src/it/localizer/src/main/java/test/X.java
@@ -1,0 +1,9 @@
+package test;
+
+public class X {
+
+    public static String label() {
+        return Messages.label();
+    }
+
+}

--- a/src/it/localizer/src/main/resources/index.jelly
+++ b/src/it/localizer/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/localizer/src/main/resources/test/Messages.properties
+++ b/src/it/localizer/src/main/resources/test/Messages.properties
@@ -1,0 +1,1 @@
+label=Whatever

--- a/src/it/localizer/src/test/java/test/XTest.java
+++ b/src/it/localizer/src/test/java/test/XTest.java
@@ -1,0 +1,13 @@
+package test;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class XTest {
+
+    @Test
+    public void label() throws Exception {
+        assertEquals("Whatever", X.label());
+    }
+
+}


### PR DESCRIPTION
Reported in https://github.com/jenkinsci/plugin-pom/pull/426#issuecomment-889532987. Picks up fix from https://github.com/jenkinsci/lib-access-modifier/pull/54, amending #427.