### PR TITLE
Avoid losing the focus because ForkedBooter on MacOS when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -742,6 +742,8 @@
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
+          <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
+          <argLine>-Djava.awt.headless=true</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -760,6 +762,8 @@
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
+          <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
+          <argLine>-Djava.awt.headless=true</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,8 @@
           <minimumJavaVersion>1.${java.level}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
+            <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
+            <java.awt.headless>true</java.awt.headless>
           </systemProperties>
         </configuration>
       </plugin>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Added a couple of arguments to the jvm that is forked when running tests to avoid losing the focus when you run the maven tests in the background in MacOS. It's very annoying every time a fork is created you lose the focus where you were.

I manually tested with a plugin using this modified version. When the plugin run the tests, the Java icon doesn't show up anymore.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
