### PR TITLE
Revert #443 (`argLine` modification)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,8 +643,6 @@
           <minimumJavaVersion>1.${java.level}</minimumJavaVersion>
           <systemProperties>
             <hudson.Main.development>${hudson.Main.development}</hudson.Main.development>
-            <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
-            <java.awt.headless>true</java.awt.headless>
           </systemProperties>
         </configuration>
       </plugin>
@@ -744,8 +742,6 @@
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
-          <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
-          <argLine>-Djava.awt.headless=true</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -764,8 +760,6 @@
             </property>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
-          <!-- to avoid losing the focus on MacOS when a new forked jvm is created -->
-          <argLine>-Djava.awt.headless=true</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Reverting #443 since it apparently breaks JaCoCo integration. Hotfix; a proper fix should

* add an IT for JaCoCo
* try to solve the original Mac-specific problem in the proper way (optionally with an IT)