### PR TITLE
Do not reuse surefire (failsafe) forks for test stability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <releaseProfiles> </releaseProfiles>
     <arguments> </arguments>
-    <argLine>-Xms768M -Xmx768M -Djava.awt.headless=true -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
+    <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
 
     <jenkins.version>2.204</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
@@ -731,17 +731,13 @@
         <configuration>
           <!-- SUREFIRE-1226 workaround -->
           <trimStackTrace>false</trimStackTrace>
-          <systemProperties>
-            <property>
-              <name>hudson.udp</name>
-              <value>-1</value>
-            </property>
-            <property>
-              <name>java.io.tmpdir</name>
-              <value>${surefireTempDir}</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+              <hudson.udp>-1</hudson.udp>
+              <java.io.tmpdir>${surefireTempDir}</java.io.tmpdir>
+              <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
           <runOrder>alphabetical</runOrder>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin>
@@ -749,17 +745,13 @@
         <configuration>
           <!-- SUREFIRE-1226 workaround -->
           <trimStackTrace>false</trimStackTrace>
-          <systemProperties>
-            <property>
-              <name>hudson.udp</name>
-              <value>-1</value>
-            </property>
-            <property>
-              <name>java.io.tmpdir</name>
-              <value>${surefireTempDir}</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+              <hudson.udp>-1</hudson.udp>
+              <java.io.tmpdir>${surefireTempDir}</java.io.tmpdir>
+              <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
           <runOrder>alphabetical</runOrder>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Reusing forks is a cause of flakyness in tests, especially ones with `JenkinsRule`a, as Jenkins itself has many things static that may get left in a zombie like state in between tests. 

for example:

```
java.lang.IllegalThreadStateException
	at java.lang.ThreadGroup.addUnstarted(ThreadGroup.java:867)
	at java.lang.Thread.init(Thread.java:405)
	at java.lang.Thread.init(Thread.java:349)
	at java.lang.Thread.<init>(Thread.java:678)
	at java.util.concurrent.Executors$DefaultThreadFactory.newThread(Executors.java:613)
	at hudson.util.DaemonThreadFactory.newThread(DaemonThreadFactory.java:47)
	at hudson.util.ClassLoaderSanityThreadFactory.newThread(ClassLoaderSanityThreadFactory.java:23)
	at hudson.util.NamingThreadFactory.newThread(NamingThreadFactory.java:52)
	at hudson.util.ExceptionCatchingThreadFactory.newThread(ExceptionCatchingThreadFactory.java:51)
	at java.util.concurrent.ThreadPoolExecutor$Worker.<init>(ThreadPoolExecutor.java:619)
	at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:932)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1378)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
	at hudson.Proc.joinWithTimeout(Proc.java:159)
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2670)
Caused: hudson.plugins.git.GitException: Error performing git command: git ls-remote /jenkins/workspace/ATH/without-exclusion-list/pct-all-without-exclusion-list-master/output-copyartifact/work/copyartifact/target/tmp/junit7915221725496369620/junit2953409998593936139
	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2685)

```

At the same time update the surefire systemProperty configuration to the
non deprecated systemPropertyVariables and move the headless propery
defintion there.

Whilst the above is also a bug in Jenkins that could occur in production depending on exactly what loads the `Proc` class first, re-using forks can trigger a lot of other flakyness. 

@mikecirioli / @MRamonLeon this *may* also fix your bouncing doc / focus issue (but is not the focus of this PR)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
