### PR TITLE
Clean up old `requireUpperBoundDeps` exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,11 +539,7 @@
                   <excludes>
                     <exclude>javax.servlet:javax.servlet-api</exclude>
                     <exclude>javax.servlet:servlet-api</exclude>
-                    <exclude>com.google.guava:guava</exclude> <!-- TODO needed for Jenkins 2.71 and earlier -->
-                    <exclude>commons-logging:commons-logging</exclude> <!-- ditto -->
                     <exclude>com.google.code.findbugs:annotations</exclude>
-                    <exclude>com.google.code.findbugs:jsr305</exclude> <!-- ditto -->
-                    <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>


### PR DESCRIPTION
Noticed looking at #456. If I read #269 right, these have been unnecessary since 4.0.
