### PR TITLE
Ban vulnerable versions of Apache Log4j 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,7 +526,7 @@
                 <bannedDependencies>
                   <excludes>
                     <exclude>javax.servlet:servlet-api</exclude>
-                    <exclude>org.apache.logging.log4j:*:(,2.14.1]</exclude> <!-- CVE-2021-44228 -->
+                    <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude> <!-- CVE-2021-44228 -->
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
                     <exclude>log4j:log4j:*:jar:compile</exclude>
                     <exclude>log4j:log4j:*:jar:runtime</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,7 @@
                 <bannedDependencies>
                   <excludes>
                     <exclude>javax.servlet:servlet-api</exclude>
+                    <exclude>org.apache.logging.log4j:*:(,2.14.1]</exclude> <!-- CVE-2021-44228 -->
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
                     <exclude>log4j:log4j:*:jar:compile</exclude>
                     <exclude>log4j:log4j:*:jar:runtime</exclude>


### PR DESCRIPTION
Ban Apache Log4j 2.15.0-rc1 and earlier via Maven Enforcer.