### PR TITLE
Stop relying on core for annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>4.5.1</version>
-      <scope>provided</scope>
       <optional>true</optional>
       <exclusions>
         <exclusion>
@@ -217,7 +216,7 @@
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <scope>provided</scope>
+      <version>1.0</version>
       <optional>true</optional>
     </dependency>
 
@@ -239,7 +238,7 @@
       <groupId>org.kohsuke</groupId>
       <artifactId>access-modifier-annotation</artifactId>
       <version>${access-modifier-checker.version}</version>
-      <scope>provided</scope>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <!-- provided by Jenkins core -->


### PR DESCRIPTION
Implements choice 1 from [this mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/89hziiKhQxs/m/_WGiA5pUCwAJ). Pairs with jenkinsci/jenkins#6056, stapler/stapler#293, and jenkinsci/lib-access-modifier#75.