### PR TITLE
Exclude `javax.servlet:servlet-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
         <version>${jenkins.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
@@ -122,6 +128,12 @@
         <version>${jenkins.version}</version>
         <type>executable-war</type>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
Without this exclusion, recent versions of Maven Enforcer fail against recent cores with:

```
Require upper bound dependencies error for javax.servlet:servlet-api:0 [provided] paths to dependency are:
+-org.jenkins-ci.plugins:gitlab-plugin:1.5.25-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.326-SNAPSHOT [provided]
    +-javax.servlet:servlet-api:0 [provided] (managed) <-- javax.servlet:servlet-api:[0] [provided]
and
+-org.jenkins-ci.plugins:gitlab-plugin:1.5.25-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-war:2.326-SNAPSHOT [test]
    +-javax.servlet:servlet-api:0 [provided] (managed) <-- javax.servlet:servlet-api:[0] [provided]
and
+-org.jenkins-ci.plugins:gitlab-plugin:1.5.25-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.326-SNAPSHOT [provided]
    +-org.jenkins-ci.main:cli:2.326-SNAPSHOT [provided]
      +-javax.servlet:servlet-api:0 [provided] (managed) <-- javax.servlet:servlet-api:[0] [provided]
```