### PR TITLE
Bump `access-modifier` from 1.25 to 1.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <hudson.Main.development>true</hudson.Main.development>
 
     <mockito.version>4.1.0</mockito.version>
-    <access-modifier-checker.version>1.25</access-modifier-checker.version>
+    <access-modifier-checker.version>1.27</access-modifier-checker.version>
     <animal.sniffer.version>1.20</animal.sniffer.version>
 
     <!-- To opt in to @Restricted(Beta.class) APIs, set to true: -->


### PR DESCRIPTION
See [the release notes](https://github.com/jenkinsci/lib-access-modifier/releases/tag/access-modifier-1.26).