### PR TITLE
Bump `jenkins-test-harness` from 1666.vd1360abbfe9e to 1674.v3b8b1441e939

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <jenkins.version>2.204</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
 
-    <jenkins-test-harness.version>1666.vd1360abbfe9e</jenkins-test-harness.version>
+    <jenkins-test-harness.version>1674.v3b8b1441e939</jenkins-test-harness.version>
 
     <hpi-plugin.version>3.22</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>


### PR DESCRIPTION
See [the release notes](https://github.com/jenkinsci/jenkins-test-harness/releases/tag/1674.v3b8b1441e939).