### PR TITLE
Bump Jenkins version to 2.249; clean up plugin parent POM

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you had a `jar:test-jar` execution, delete it and add to `properties`:
 The plugin POM is designed for plugin builds with JDK 8 or above,
 but target `java.level` for a plugin may differ from a JDK version used for the build.
 Starting from Plugin POM `3.44`, support of Java 7 targets in Plugin POM is deprecated and has been removed in `4.0`,
-`java.level=8` and `jenkins.version>2.204.1` are expected to be used for most plugins.
+`java.level=8` and `jenkins.version>2.249.1` are expected to be used for most plugins.
 
 
 ## Incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <arguments />
     <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
 
-    <jenkins.version>2.204</jenkins.version>
+    <jenkins.version>2.249</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
 
     <jenkins-test-harness.version>1674.v3b8b1441e939</jenkins-test-harness.version>
@@ -232,18 +232,6 @@
 
     <!-- static analysis -->
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
       <scope>provided</scope>
@@ -264,19 +252,6 @@
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>access-modifier-annotation</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-      <exclusions>
-        <exclusion>
-          <!-- provided by Jenkins core -->
-          <groupId>org.jenkins-ci</groupId>
-          <artifactId>annotation-indexer</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.249</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <repositories>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.249</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.249</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <repositories>

--- a/src/it/undefined-java-level/pom.xml
+++ b/src/it/undefined-java-level/pom.xml
@@ -13,7 +13,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.204</jenkins.version>
+        <jenkins.version>2.249</jenkins.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
Implements recent suggestions from the "annotation versions" mailing list thread.