### PR TITLE
Exclude HTMLUnit from code coverage checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1148,6 +1148,8 @@
             <configuration>
               <excludes>
                 <exclude>**/Messages.class</exclude>
+                <!-- https://github.com/HtmlUnit/htmlunit-cssparser/issues/4 -->
+                <exclude>com/gargoylesoftware/**</exclude>
               </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
Noticed in workflow-job plugin `org.jenkinsci.plugins.workflow.job.WorkflowRunRestartTest.termAndKillInSidePanel` (while looking at https://github.com/jenkinsci/workflow-job-plugin/pull/235)

I don't know if it's causing any harm other than log spam but seems easy to fix.

Tested in workflow-job