### PR TITLE
EOL `java.level.test`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ thought to be overridden are no longer based on properties. The main remaining o
   * `hpi-plugin.version`: The HPI Maven Plugin version used by the plugin.
   (Generally you should not set this to a version _lower_ than that specified in the parent POM.)
   * `stapler-plugin.version`: The Stapler Maven plugin version required by the plugin.
-  * `java.level.test`: The Java version to use to build the plugin tests.
   * In order to make their versions the same as the used core version, `node.version` and `npm.version`
   properties are provided.
 * Tests are skipped during the `perform` phase of a release (can be overridden by setting `release.skipTests` to false).

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,6 @@
     <hpi-plugin.version>3.23</hpi-plugin.version>
     <stapler-plugin.version>1.17</stapler-plugin.version>
     <java.level>you-must-override-the-java.level-property</java.level>
-    <!-- Change this property if you need your tests to be compiled with a different Java level than the plugin. -->
-    <!-- Use only if strictly necessary. It may cause problems in your IDE. -->
-    <java.level.test>${java.level}</java.level.test>
 
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
@@ -704,8 +701,8 @@
         <configuration>
           <source>1.${java.level}</source>
           <target>1.${java.level}</target>
-          <testSource>1.${java.level.test}</testSource>
-          <testTarget>1.${java.level.test}</testTarget>
+          <testSource>1.${java.level}</testSource>
+          <testTarget>1.${java.level}</testTarget>
         </configuration>
       </plugin>
       <plugin>
@@ -967,6 +964,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
               <release>${java.level}</release>
+              <testRelease>${java.level}</testRelease>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
[As far as I can tell](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22java.level.test%22), this feature is not used anywhere: a code search shows that in the handful of cases where `java.level.test` is explicitly set at all, it is set to the same value as `java.level`. Having a separate tunable for the Java level for tests makes the POM more complex and makes it more difficult to implement changes to the POM, so I am proposing we dispense with this feature in order to simplify the POM. If and when this feature is needed again in the future, we can always reintroduce it.