### PR TITLE
Avoid MCOMPILER-485 in compiler plugin 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
 
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
+
+    <!-- Avoid maven compiler plugin 3.10.0 bug -->
+    <!-- https://issues.apache.org/jira/browse/MCOMPILER-485 -->
+    <!-- TODO remove when MCOMPILER-485 is fixed -->
+    <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Avoid [MCOMPILER-485](https://issues.apache.org/jira/browse/MCOMPILER-485) in compiler plugin 3.10.0

Maven 3.10.0 added a feature to create missing package-info files. The feature incorrectly uses Windows-style directory separators on Windows.  Other parts of the code expect to always see Unix style directory separators.

Disable the new feature so that it does not break compilation.  See [Jenkins developer mailing list conversation](https://groups.google.com/g/jenkinsci-dev/c/077VYgtSLXo/m/6JQjJs7-AQAJ) for details.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I'm not expert enough in Maven development to create the integration test to confirm the issue is resolved.  I assume it would require a Java package that does not have a package-info file and then a check on Windows that some internal path to the generated package-info file is using Windows directory separators.