### PR TITLE
Remove obsolete workaround for MCOMPILER-485

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,11 +114,6 @@
 
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
-
-    <!-- Avoid maven compiler plugin 3.10.0 bug -->
-    <!-- https://issues.apache.org/jira/browse/MCOMPILER-485 -->
-    <!-- TODO remove when MCOMPILER-485 is fixed -->
-    <maven.compiler.createMissingPackageInfoClass>false</maven.compiler.createMissingPackageInfoClass>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
#506 added a workaround for MCOMPILER-485, a bug present in Maven Compiler Plugin 3.10.0. A fix was released in 3.10.1, and we have upgraded to that release in #515, so the workaround is now obsolete and should be removed.