### PR TITLE
[JENKINS-54842] Define compiler configuration with Maven properties where possible and use Java 11 built-in functionality instead of Animal Sniffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
-    <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
-    <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
@@ -946,6 +944,8 @@
         <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.testRelease>8</maven.compiler.testRelease>
         <animal.sniffer.skip>true</animal.sniffer.skip>
+        <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
+        <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -952,6 +952,7 @@
       <properties>
         <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.testRelease>8</maven.compiler.testRelease>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -54,18 +54,19 @@
   </distributionManagement>
 
   <properties>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
-    <!--
-      Work around MCOMPILER-346.
-      TODO When MCOMPILER-346 is resolved, this should be deleted.
-    -->
+    <!-- Work around openjdk/jdk11u-dev#919. TODO When we upgrade to OpenJDK 11.0.16, this should be deleted. -->
     <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- Generate metadata for reflection on method parameters -->
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+
     <releaseProfiles />
     <arguments />
     <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
@@ -119,9 +120,6 @@
     <scmTag>HEAD</scmTag>
     <!-- Where to put temporary files during test runs. -->
     <surefireTempDir>${project.build.directory}/tmp</surefireTempDir>
-
-    <!-- Generate metadata for reflection on method parameters -->
-    <maven.compiler.parameters>true</maven.compiler.parameters>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+    <!--
+      Work around MCOMPILER-346.
+      TODO When MCOMPILER-346 is resolved, this should be deleted.
+    -->
+    <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -697,16 +702,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!--
-            Work around MCOMPILER-346.
-            TODO When MCOMPILER-346 is resolved, this should be deleted.
-          -->
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
   </distributionManagement>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -338,7 +342,6 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
-            <source>8</source>
             <quiet>true</quiet>
             <links>
               <link>https://javadoc.jenkins.io/</link>
@@ -698,10 +701,6 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <testSource>1.8</testSource>
-          <testTarget>1.8</testTarget>
           <!--
             Work around MCOMPILER-346.
             TODO When MCOMPILER-346 is resolved, this should be deleted.
@@ -950,17 +949,10 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <release>8</release>
-              <testRelease>8</testRelease>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.testRelease>8</maven.compiler.testRelease>
+      </properties>
     </profile>
     <profile>
       <id>jenkins-release</id>


### PR DESCRIPTION
This change should be functionally equivalent to the existing code, and by itself it doesn't buy us anything, but in concert with https://github.com/jenkinsci/maven-hpi-plugin/pull/323, this allows us to require Java 11 in the future without an awkward flag day.