### PR TITLE
add spotless

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ If you had a `jar:test-jar` execution, delete it and add to `properties`:
 <no-test-jar>false</no-test-jar>
 ```
 
+To fix spotless validation errors:
+
+```bash
+mvn spotless:apply
+```
+
+To disable spotless validation
+
+```xml
+<spotless.check.skip>true</spotless.check.skip>
+```
+
 ## Java support
 
 The plugin POM is designed for plugin builds with JDK 8 or above.

--- a/pom.xml
+++ b/pom.xml
@@ -129,35 +129,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-core</artifactId>
-        <version>${jenkins.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-war</artifactId>
-        <version>${jenkins.version}</version>
-        <type>executable-war</type>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-test-harness</artifactId>
-        <version>${jenkins-test-harness.version}</version>
-      </dependency>
       <!-- JTN tidy this up? -->
       <dependency>
         <!-- used in JTH and jenkins core > 2.x -->
@@ -192,6 +163,22 @@
         <version>1.4</version>
       </dependency>
       <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-core</artifactId>
+        <version>${jenkins.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-test-harness</artifactId>
+        <version>${jenkins-test-harness.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
@@ -206,22 +193,29 @@
         <artifactId>objenesis</artifactId>
         <version>3.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-war</artifactId>
+        <version>${jenkins.version}</version>
+        <type>executable-war</type>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
-    <!--  Jenkins core dependencies -->
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
+      <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
+      <!-- TODO this would be better as a managed version of [0] -->
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <!-- jenkins war needed for testing -->
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <type>executable-war</type>
-      <scope>test</scope>
     </dependency>
 
     <!-- dependencies provided by virtue of running in Jenkins -->
@@ -247,17 +241,15 @@
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <!-- to avoid https://www.slf4j.org/codes.html#release warning -->
-      <!-- TODO this would be better as a managed version of [0] -->
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
+    <!--  Jenkins core dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
+      <artifactId>jenkins-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -265,9 +257,17 @@
       <artifactId>test-annotations</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- jenkins war needed for testing -->
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-war</artifactId>
+      <type>executable-war</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -665,7 +665,7 @@
             <phase>validate</phase>
             <configuration>
               <rules>
-                <!-- 
+                <!--
                   this causes fails the incrementals IT to fail as the parent is a snapshot and the incremental is a release
                   so this is a separate execution so that it can be skipped in that specific IT
                   -->
@@ -859,17 +859,17 @@
               <generateLicenseXml>target/${project.artifactId}/WEB-INF/licenses.xml</generateLicenseXml>
               <inlineScript><![CDATA[filter {
                     def plugins = [] as Set
-                    
+
                     // collect all Jenkins plugins
                     models.entrySet().each { e ->
                         if (e.value.packaging=="hpi")
                             plugins.add(e.key.id)
                     }
-                    
+
                     // filter out dependencies that don't belong to this plugin
                     models.entrySet().removeAll(models.entrySet().findAll { e ->
                         def a = e.key;
-                        
+
                         if (a.dependencyTrail.size()>0 && plugins.contains(a.dependencyTrail[1]))
                             return true; // ignore transitive dependencies through other plugins
 
@@ -878,7 +878,7 @@
                         // dependencies into the artifact list.
                         if (a.dependencyTrail.find { trail -> trail.contains(":hudson-core:") || trail.contains(":jenkins-core:") })
                             return true;
-                            
+
                         return false;
                     })
                 }]]></inlineScript>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,8 @@
     <scmTag>HEAD</scmTag>
     <!-- Where to put temporary files during test runs. -->
     <surefireTempDir>${project.build.directory}/tmp</surefireTempDir>
+    <spotless.version>2.22.1</spotless.version>
+    <sort.nrOfIndentSpace>2</sort.nrOfIndentSpace>
   </properties>
 
   <dependencyManagement>
@@ -461,6 +463,11 @@
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.2.3</version>
+        </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -925,6 +932,42 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless.version}</version>
+        <configuration>
+          <java>
+            <endWithNewline />
+            <importOrder />
+            <indent>
+              <spaces>true</spaces>
+            </indent>
+            <removeUnusedImports />
+            <trimTrailingWhitespace />
+          </java>
+          <pom>
+            <sortPom>
+              <encoding>${project.build.sourceEncoding}</encoding>
+              <lineSeparator>\n</lineSeparator>
+              <expandEmptyElements>false</expandEmptyElements>
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              <sortDependencies>scope,groupId,artifactId</sortDependencies>
+              <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
+              <nrOfIndentSpace>${sort.nrOfIndentSpace}</nrOfIndentSpace>
+            </sortPom>
+          </pom>
+        </configuration>
+        <executions>
+          <execution>
+            <!-- Runs in verify phase by default -->
+            <goals>
+              <!-- Can be disabled using -Dspotless.check.skip -->
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -965,6 +1008,7 @@
       <properties>
         <skipTests>${release.skipTests}</skipTests>
         <spotbugs.skip>${release.skipTests}</spotbugs.skip>
+        <spotless.check.skip>${release.skipTests}</spotless.check.skip>
         <invoker.skip>${release.skipTests}</invoker.skip>
       </properties>
       <build>
@@ -1507,6 +1551,7 @@
         <!-- we can not use maven.test.skip because we may be producing a test jar -->
         <skipTests>true</skipTests>
         <spotbugs.skip>true</spotbugs.skip>
+        <spotless.check.skip>true</spotless.check.skip>
         <enforcer.skip>true</enforcer.skip>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <animal.sniffer.skip>true</animal.sniffer.skip>

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>benchmark-it</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <properties>
-        <jenkins.version>2.249</jenkins.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>benchmark-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <properties>
+    <jenkins.version>2.249</jenkins.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-fail/downstream/pom.xml
+++ b/src/it/beta-fail/downstream/pom.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-fail</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -1,35 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-fail</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.277.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-fail</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.277.4</jenkins.version>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-fail/upstream/pom.xml
+++ b/src/it/beta-fail/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-fail</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/beta-just-testing/downstream/pom.xml
+++ b/src/it/beta-just-testing/downstream/pom.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-just-testing</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-just-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -1,35 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-just-testing</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.277.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-just-testing</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.277.4</jenkins.version>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-just-testing/upstream/pom.xml
+++ b/src/it/beta-just-testing/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-just-testing</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-just-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/beta-pass/downstream/pom.xml
+++ b/src/it/beta-pass/downstream/pom.xml
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-pass</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <properties>
-        <useBeta>true</useBeta>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <properties>
+    <useBeta>true</useBeta>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -1,35 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-pass</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.277.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-pass</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.277.4</jenkins.version>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-pass/upstream/pom.xml
+++ b/src/it/beta-pass/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-pass</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>incrementals-and-plugin-bom</artifactId>
-    <version>${revision}${changelist}</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <revision>1.0</revision>
-        <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.249</jenkins.version>
-    </properties>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>4</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>incrementals-and-plugin-bom</artifactId>
+  <version>${revision}${changelist}</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <revision>1.0</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.249</jenkins.version>
+  </properties>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.176.x</artifactId>
+        <version>4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/localizer/pom.xml
+++ b/src/it/localizer/pom.xml
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>localizer</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <jenkins.version>2.277.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>localizer</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>2.277.4</jenkins.version>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/localizer/src/test/java/test/XTest.java
+++ b/src/it/localizer/src/test/java/test/XTest.java
@@ -1,7 +1,8 @@
 package test;
 
-import org.junit.Test;
 import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 public class XTest {
 

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -1,37 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>sample-plugin</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <jenkins.version>2.249</jenkins.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>sample-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>2.249</jenkins.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.5</version>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/sample-plugin/src/test/java/test/SampleRootActionTest.java
+++ b/src/it/sample-plugin/src/test/java/test/SampleRootActionTest.java
@@ -1,9 +1,10 @@
 package test;
 
-import org.apache.commons.io.IOUtils;
-import org.junit.Test;
 import static org.junit.Assert.*;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class SampleRootActionTest {


### PR DESCRIPTION
Implement spotless with sane defaults. I don't think we need to go down the rabbit hole of configuration.
I added an example for `<sort.nrOfIndentSpace>2</sort.nrOfIndentSpace>` 

I would like to remove it simply keep sane defaults and than if someone dislike it they can either override the configuration or use `spotless.check.skip` to skip.

At the moment this opt-out via `<spotless.check.skip>true</spotless.check.skip>`

If there is any desire we can also make it opt-in by setting it to default `<spotless.check.skip>false/spotless.check.skip>`

Not sure who should be pinged to properly review this.

@basil 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
