### PR TITLE
Work around JENKINS-68568

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -958,6 +958,49 @@
         <!-- Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs. -->
         <jenkins.addOpens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED</jenkins.addOpens>
       </properties>
+      <!--
+        Maven HPI plugin 3.27 or later (which is included in plugin parent POM 4.40 or later) almost
+        allows the plugin POM to support cores that require both Java 8 and Java 11 by dynamically
+        reconfiguring "maven.compiler.release" and "maven.compiler.testRelease" (which default to 8
+        in order to support cores prior to 2.357) to the version of Java that
+        "jenkins/model/Jenkins.class" was compiled with (which could be 11 with 2.357 or later):
+        "almost" because Enforcer's bytecode version check still gets in the way if a plugin has a
+        baseline of 2.357 or later and has a library on its classpath with Java 11 bytecode.
+        Unfortunately, there is no easy way for Maven HPI plugin to dynamically reconfigure Enforcer
+        for Java 11 the same way it dynamically reconfigures Maven Compiler Plugin for Java 11. So in
+        order for the plugin POM to support baselines before and after 2.357 and allow plugins to
+        use Java 11 features with a baseline of 2.357 or later if so desired, we work around the
+        problem by increasing the maximum JDK version for Enforcer to 11 below. While technically
+        incorrect (in the sense that it fails to enforce the absence of Java 9, 10, or 11 bytecode
+        when it should) when building, testing, or releasing a plugin with a baseline prior to 2.357
+        using a Java 11 compiler (including CD), any such plugin should have a "Jenkinsfile" build
+        running on Java 8, where the correct enforcement should be present, so this should not cause
+        any practical problems. This workaround is justified because the alternative (raising the
+        minimum Jenkins version for the plugin POM to 2.357 or later and dropping support for Java
+        8) would be overly harsh on users, causing Dependabot updates to fail for the majority of
+        users who do not want to update their baseline so aggressively. When we are ready to raise
+        the minimum Jenkins version for the plugin POM to 2.357 or later and drop support for Java
+        8, this workaround can be deleted.
+      -->
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>display-info</id>
+                <configuration>
+                  <rules>
+                    <enforceBytecodeVersion>
+                      <maxJdkVersion>11</maxJdkVersion>
+                    </enforceBytecodeVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>jenkins-release</id>


### PR DESCRIPTION
Maven HPI plugin 3.27 or later (which is included in plugin parent POM 4.40 or later) almost allows the plugin POM to support cores that require both Java 8 and Java 11 by dynamically reconfiguring `maven.compiler.release` and `maven.compiler.testRelease` (which default to 8 in order to support cores prior to 2.357) to the version of Java that `jenkins/model/Jenkins.class` was compiled with (which could be 11 with 2.357 or later): "almost" because Enforcer's bytecode version check still gets in the way if a plugin has a baseline of 2.357 or later and has a library on its classpath with Java 11 bytecode. Unfortunately, there is no easy way for Maven HPI plugin to dynamically reconfigure Enforcer for Java 11 the same way it dynamically reconfigures Maven Compiler Plugin for Java 11. So in order for the plugin POM to support baselines before and after 2.357 and allow plugins to use Java 11 features with a baseline of 2.357 or later if so desired, we work around the problem by increasing the maximum JDK version for Enforcer to 11 below. While technically incorrect (in the sense that it fails to enforce the absence of Java 9, 10, or 11 bytecode when it should) when building, testing, or releasing a plugin with a baseline prior to 2.357 using a Java 11 compiler (including CD), any such plugin should have a `Jenkinsfile` build running on Java 8, where the correct enforcement should be present, so this should not cause any practical problems. This workaround is justified because the alternative (raising the minimum Jenkins version for the plugin POM to 2.357 or later and dropping support for Java 8) would be overly harsh on users, causing Dependabot updates to fail for the majority of users who do not want to update their baseline so aggressively. When we are ready to raise the minimum Jenkins version for the plugin POM to 2.357 or later and drop support for Java 8, this workaround can be deleted.

### Testing done

Ran `mvn clean verify -Djenkins.version=2.357 -Djgit.version=6.2.0.202206071550-r -DskipTests` in `git-client` before and after this PR, with Java 11. Before this PR, trying to compile with 2.357 and JGit should have worked, because the core is new enough to support Java 11; however, it failed the Enforcer check as expected. After this PR, it passed the Enforcer check as expected.