### PR TITLE
Revert "Add `specific-test` profile"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1169,17 +1169,6 @@
       </properties>
     </profile>
     <profile>
-      <id>specific-test</id>
-      <activation>
-        <property>
-          <name>test</name>
-        </property>
-      </activation>
-      <properties>
-        <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
-      </properties>
-    </profile>
-    <profile>
       <id>enable-jacoco</id>
       <build>
         <plugins>


### PR DESCRIPTION
Reverts jenkinsci/plugin-pom#568

is a backwards step and there was no justification for the original other than "it was in core".

[not failing a build](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#failIfNoSpecifiedTests) when you pass `-Dtest=Foo` and there is no matching tests is not applicable to 90%[1] of Jenkins plugins which are not multi-nodule and would be a regression in expected user behaviour.  the few plugins multimodule plugins that needs this could add that profile if the developers wanted that functionality

@basil 

[1] not a statistically valid number