### PR TITLE
Use JUnit Jupiter aggregator artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Plugins that want to use parameterized tests with JUnit 5 will currently get `error: package org.junit.jupiter.params does not exist` because the `junit-jupiter-params` is not on the classpath. This PR solves the problem by trading the `junit-jupiter-engine` dependency for the `junit-jupiter` aggregator artifact, which transitively pulls in dependencies on `junit-jupiter-api`, `junit-jupiter-params`, and `junit-jupiter-engine` for simplified dependency management in build tools such as Gradle and Maven, consistent with https://github.com/jenkinsci/jenkins/pull/6842.