### PR TITLE
add junit 4.x to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
         <version>3.1.0</version>
       </dependency>
       <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.9.0</version>


### PR DESCRIPTION
https://github.com/jenkinsci/configuration-as-code-plugin/pull/2078#issuecomment-1208658342

We should still keep at least a dependency management version on junit 4.x for all plugins that continue to use `junit` annotations.