### PR TITLE
Update Node from 4.0.0 to 16.17.1 and npm from 2.13.1 to 8.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
     <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
     <no-test-jar>true</no-test-jar>
 
-    <node.version>4.0.0</node.version>
-    <npm.version>2.13.1</npm.version>
+    <node.version>16.17.1</node.version>
+    <npm.version>8.19.2</npm.version>
     <yarn.version>0.23.0</yarn.version>
     <frontend-version>1.12.1</frontend-version>
     <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>


### PR DESCRIPTION
The change proposed updates the couple of dependencies to their maintained LTS versions, instead of shipping a version that is ~8 years out of date (and 6 years out of maintenance).