### PR TITLE
Remove yarn.version default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
     <node.version>you-must-override-the-node.version-property</node.version>
     <npm.version>you-must-override-the-npm.version-property</npm.version>
-    <yarn.version>0.23.0</yarn.version>
+    <yarn.version>you-must-override-the-yarn.version-property</yarn.version>
     <frontend-version>1.12.1</frontend-version>
     <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
     <npmDownloadRoot>https://repo.jenkins-ci.org/npm-dist/</npmDownloadRoot>


### PR DESCRIPTION
Amending https://github.com/jenkinsci/plugin-pom/pull/614, this PR removes the default version set for yarn.
v0.23.0 was released more than 5 years ago (April 2017) towards yarn 1.x, which is EOL for several years.
Given, you'll want to use a supported version, you need to overwrite this variable anyway, with berry or the newest, and still unsupported, 1.x release.