### PR TITLE
Remove duplicate SpotBugs defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,13 +75,6 @@
     <hpi-plugin.version>3.35</hpi-plugin.version>
     <stapler-plugin.version>1.20</stapler-plugin.version>
 
-    <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
-         Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
-      -->
-    <spotbugs.threshold>Medium</spotbugs.threshold>
-    <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->
-    <spotbugs.effort>Default</spotbugs.effort>
-
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
     <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
@@ -684,9 +677,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <configuration>
-          <failOnError>${spotbugs.failOnError}</failOnError>
-        </configuration>
         <executions>
           <execution>
             <id>spotbugs</id>
@@ -699,8 +689,6 @@
               <!--  Instead we configure this in a profile -->
               <xmlOutput>true</xmlOutput>
               <spotbugsXmlOutput>false</spotbugsXmlOutput>
-              <effort>${spotbugs.effort}</effort>
-              <threshold>${spotbugs.threshold}</threshold>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
The version of the SpotBugs Maven Plugin that we are using already defines the `failOnError`, `effort`, `threshold`, and `excludeFilterFile` mojo parameters to the values of the `spotbugs.failOnError`, `spotbugs.threshold`, `spotbugs.effort`, or `spotbugs.excludeFilterFile` properties if set, with the same defaults as ours if these properties are not set (see https://github.com/spotbugs/spotbugs-maven-plugin/blob/f01a7f6b99da3d2e6dcdbddd20f0b4e4dfac73fa/src/main/groovy/org/codehaus/mojo/spotbugs/BaseViolationCheckMojo.groovy). As such it is completely redundant to declare these defaults ourselves and configure the mojo with them. To test this, I compiled the Confluence Publisher plugin with these changes and observed that the `spotbugs.failOnError` setting still took effect with the changes in this PR.