### PR TITLE
Upgrade SpotBugs from 4.2.3 to 4.7.2.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,5 +30,3 @@ updates:
   - dependency-name: javax.servlet:javax.servlet-api
     versions:
     - ">= 0"
-  # TODO https://github.com/spotbugs/spotbugs/issues/1601#issuecomment-885341270
-  - dependency-name: com.github.spotbugs:spotbugs-maven-plugin

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
     <hpi-plugin.version>3.35</hpi-plugin.version>
     <stapler-plugin.version>1.20</stapler-plugin.version>
 
+    <!--
+      The MS_EXPOSE_REP, EI_EXPOSE_REP, EI_EXPOSE_REP2, EI_EXPOSE_STATIC_REP2, MS_EXPOSE_BUF,
+      EI_EXPOSE_BUF, EI_EXPOSE_STATIC_BUF2, and EI_EXPOSE_BUF2 bug patterns are noisy and create
+      little value; therefore, we suppress them globally.
+    -->
+    <spotbugs.omitVisitors>FindReturnRef</spotbugs.omitVisitors>
+
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
@@ -468,7 +475,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.2.3</version>
+          <version>4.7.2.1</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
The main reason we had suppressed this upgrade in https://github.com/spotbugs/spotbugs/issues/1601#issuecomment-885341270 was because of some newly-added noisy bug patterns. Those bug patterns don't appear to have been fixed in the intervening year, so suppress them globally to allow us to complete the upgrade. To test this change I ran SpotBugs on `workflow-cps` and confirmed there were tons of new violations until I added `<spotbugs.omitVisitors>FindReturnRef</spotbugs.omitVisitors>` after which there were no new violations.