### PR TITLE
Remove explicit dependency on `jcip-annotations`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,14 +233,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- static analysis -->
-    <dependency>
-      <groupId>net.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-
     <!-- for JRE requirement check annotation -->
     <dependency>
       <!-- no need to have this at runtime -->


### PR DESCRIPTION
See [the mailing list thread](https://groups.google.com/g/jenkinsci-dev/c/89hziiKhQxs/m/JDzmcfQJCwAJ). This has been a plain dependency of `jenkins-core` since 2.224, so it is in the plugin classpath already (just like any other library). To test this I verified that the Kubernetes plugin (which uses JCIP annotations) could still be compiled with this PR.