### PR TITLE
Remove managed dependency on Objenesis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,11 +202,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.objenesis</groupId>
-        <artifactId>objenesis</artifactId>
-        <version>3.3</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Objenesis is a relatively obscure library used by very few plugins: of the popular plugins, the only one I know of that consumes it directly is `git-client`. While I think it makes sense for `jenkinsci/plugin-pom` (and by extension, `jenkinsci/pom`) to manage the versions of popular libraries like Hamcrest, JUnit, and Mockito, doing so for a library like Objenesis seems less appropriate given how rarely that library is used. Better for the few consumers like `git-client` that rely on it to manage the version on their own. To test this I verified that `org.jenkinsci.plugins.gitclient.CliGitAPIImplTest` worked after this change (and after updating `git-client` to explicitly specify the Objenesis version).