### PR TITLE
Define `surefire.forkNumber` in Surefire JVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -809,6 +809,7 @@
             <hudson.udp>-1</hudson.udp>
             <java.io.tmpdir>${surefireTempDir}</java.io.tmpdir>
             <java.awt.headless>true</java.awt.headless>
+            <surefire.forkNumber>$${surefire.forkNumber}</surefire.forkNumber>
           </systemPropertyVariables>
           <runOrder>alphabetical</runOrder>
           <reuseForks>false</reuseForks>


### PR DESCRIPTION
Matches https://github.com/jenkinsci/jenkins-test-harness/pull/513. Note the unusual escape syntax since we do not want the expression interpreted as a Maven property. Could probably also be done in `jenkinsci/pom` but I doubt there is a need, and that POM does not currently define any Surefire variables.