### PR TITLE
Inline Maven property `incrementals.url` for Maven 4 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
 
     <!-- To opt in to @Restricted(Beta.class) APIs, set to true: -->
     <useBeta>false</useBeta>
-    <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
     <!-- Where to put temporary files during test runs. -->
     <surefireTempDir>${project.build.directory}/tmp</surefireTempDir>
@@ -1273,7 +1272,7 @@
             <enabled>false</enabled>
           </snapshots>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </repository>
       </repositories>
       <pluginRepositories>
@@ -1282,7 +1281,7 @@
             <enabled>false</enabled>
           </snapshots>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </pluginRepository>
       </pluginRepositories>
     </profile>
@@ -1354,7 +1353,7 @@
       <distributionManagement>
         <repository>
           <id>incrementals</id>
-          <url>${incrementals.url}</url>
+          <url>https://repo.jenkins-ci.org/incrementals/</url>
         </repository>
       </distributionManagement>
       <build>


### PR DESCRIPTION
Building plugins with Maven 4 (alpha) fails with:
> 'profiles.profile[consume-incrementals].repositories.repository.[incrementals].url' contains an expression but should be a constant. @ org.jenkins-ci.plugins:plugin:4.53

This has already been reported to Jenkins [1] and Maven [2] and was declared as an intentional change.

[1] https://issues.jenkins.io/browse/JENKINS-67878 
[2] https://issues.apache.org/jira/browse/MNG-7420


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
