### PR TITLE
Remove unused `showDeprecation` parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,6 @@
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
-          <showDeprecation>true</showDeprecation>
           <webApp>
             <contextPath>/jenkins</contextPath>
           </webApp>


### PR DESCRIPTION
### Problem

Building a plugin with Maven 4.0.0-alpha-3 results in (among other problems)

```
[INFO] ------------------------------------------< org.jenkins-ci.plugins:text-finder >------------------------------------------
[INFO] Building Text Finder 1.23-SNAPSHOT
[INFO]   from pom.xml
[INFO] ---------------------------------------------------------[ hpi ]----------------------------------------------------------
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:validate (default-validate)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:validate-hpi (default-validate-hpi)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:insert-test (default-insert-test)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:test-hpl (default-test-hpl)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:resolve-test-dependencies (default-resolve-test-dependencies)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:test-runtime (default-test-runtime)'
[WARNING] Parameter 'showDeprecation' is unknown for plugin 'maven-hpi-plugin:3.38:hpi (default-hpi)'
```

### Evaluation

This code was originally added in jenkinsci/jenkins@5dfb1adb368f977239969e33a30dfbd911110036. At the time, compilation was handled by `maven-hpi-plugin` rather than by `maven-compiler-plugin`. Compilation was switched back to the standard `maven-compiler-plugin` in jenkinsci/maven-hpi-plugin@7c3969e8d747806c15332c864dd77f9ecf344379, and the mojo with the `showDeprecation` option was deleted in jenkinsci/maven-hpi-plugin@334506ff4cf3fcb3d53389d51886102ec8b6a148, but the configuration parameter remained. Specifying this parameter seems to have been ignored in Maven 3.x but is now showing a warning in Maven 4.x.

### Solution

Remove the unused parameter.

### Testing done

Verified that the warning was no longer shown after this parameter was removed and that compilation still succeeded.