### PR TITLE
Skip Yarn linting in `quick-build` profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1455,7 +1455,7 @@
     </profile>
 
     <profile>
-      <!--  a profile that disables as much testing as possible testing whilst still producing the artifacts -->
+      <!--  a profile that disables as much testing as possible whilst still producing the artifacts -->
       <id>quick-build</id>
       <properties>
         <!-- we can not use maven.test.skip because we may be producing a test jar -->
@@ -1466,6 +1466,7 @@
         <invoker.skip>true</invoker.skip>
         <spotless.check.skip>true</spotless.check.skip>
         <checkstyle.skip>true</checkstyle.skip>
+        <yarn.lint.skip>true</yarn.lint.skip>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Side-port of jenkinsci/pom#280 to `jenkinsci/plugin-pom`. While I was here I synchronized the comments as well by removing a typo.