### PR TITLE
Remove unnecessary default group ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1268,7 +1268,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-clean-plugin</artifactId>
             <configuration>
               <filesets>
@@ -1441,7 +1440,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>


### PR DESCRIPTION
Elsewhere in this POM, the default `groupId` of `org.apache.maven.plugins` is omitted, so omit it here as well for internal consistency.