### PR TITLE
Remove unnecessary `useReleaseProfile` configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,7 +721,6 @@
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <mavenExecutorId>forked-path</mavenExecutorId>
-          <useReleaseProfile>false</useReleaseProfile>
           <preparationGoals>clean install</preparationGoals>
           <goals>deploy</goals>
           <arguments>${arguments}</arguments>


### PR DESCRIPTION
This has been the default since the 3.x line of Maven Release Plugin, so no need to explicitly specify it here.