### PR TITLE
Remove unnecessary `enforceBytecodeVersion` excludes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,21 +526,6 @@
                   <ignoredScopes>
                     <ignoredScope>test</ignoredScope>
                   </ignoredScopes>
-                  <excludes>
-                    <!-- Makes no sense to check core itself: -->
-                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
-                    <exclude>org.jenkins-ci.main:cli</exclude>
-                    <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
-                    <exclude>org.jenkins-ci.main:remoting</exclude>
-                    <exclude>org.kohsuke.stapler:stapler</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
-                    <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
-                    <exclude>org.jenkins-ci:task-reactor</exclude>
-                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
-                    <exclude>com.google.code.findbugs:annotations</exclude>
-                    <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
-                  </excludes>
                   <!-- To add exclusions in a Jenkins plugin, use:
                   <plugin>
                       <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
I can't see a reason for these excludes, since our bytecode version is Java 11 and these dependencies don't exceed Java 11 in their bytecode. To test this I successfully ran `mvn clean verify` against Text Finder with these changes.