### PR TITLE
Upgrade from `javax.servlet-api-3.1` to `jakarta.servlet-api:4.0` and ban javax.servlet:javax.servlet-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,6 +556,7 @@
                 </enforceBytecodeVersion>
                 <bannedDependencies>
                   <excludes>
+                    <exclude>javax.servlet:javax.servlet-api</exclude>
                     <exclude>javax.servlet:servlet-api</exclude>
                     <exclude>org.sonatype.sisu:sisu-guice</exclude>
                     <exclude>log4j:log4j:*:jar:compile</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>3.1.0</maven-deploy-plugin.version>
     <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
     <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
     <maven-help-plugin.version>3.3.0</maven-help-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -171,9 +171,9 @@
       </dependency>
       <dependency>
         <!-- used in JTH and jenkins core > 2.x -->
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>3.1.0</version>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>4.0.3</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -239,8 +239,8 @@
 
     <!-- dependencies provided by virtue of running in Jenkins -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/src/it/servlet-api/invoker.properties
+++ b/src/it/servlet-api/invoker.properties
@@ -1,0 +1,3 @@
+# install, not verify, because we want to check the artifact as we would be about to deploy it
+# release.skipTests normally set in jenkins-release profile since release:perform would do the tests
+invoker.goals=-Dstyle.color=always -ntp -Pjenkins-release -Drelease.skipTests=false clean install

--- a/src/it/servlet-api/pom.xml
+++ b/src/it/servlet-api/pom.xml
@@ -1,37 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>servlet-api</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>servlet-api</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.5</version>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/servlet-api/pom.xml
+++ b/src/it/servlet-api/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>@project.version@</version>
+        <relativePath/>
+    </parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>servlet-api</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>hpi</packaging>
+    <properties>
+        <jenkins.version>2.361.4</jenkins.version>
+    </properties>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.5</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/servlet-api/src/main/resources/index.jelly
+++ b/src/it/servlet-api/src/main/resources/index.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<div/>

--- a/src/it/servlet-api/src/test/java/test/ServletAPITest.java
+++ b/src/it/servlet-api/src/test/java/test/ServletAPITest.java
@@ -1,0 +1,34 @@
+package test;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.security.LegacySecurityRealm;
+import jenkins.model.Jenkins;
+
+public class ServletAPITest {
+
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    /**
+     * When having both Servlet APIs 3.1 and 4.0 in classpath, the following error
+     * is logged on server side:
+     * 
+     * <pre>
+     * WARNING	o.e.jetty.server.HttpChannel#handleException: /jenkins/j_security_check
+     * java.lang.AbstractMethodError: Receiver class org.eclipse.jetty.security.authentication.SessionAuthentication does not define or inherit an
+     * implementation of the resolved emethod 'abstract void valueBound(javax.servlet.http.HttpSessionBindingEvent)' of interface
+     * javax.servlet.http.HttpSessionBindingListener. at org.eclipse.jetty.server.session.Session.bindValue(Session.java:357)
+     * </pre>
+     * 
+     * And then on client side getting "500 Server Error for
+     * http://localhost:.../jenkins/j_security_check"
+     */
+    @Test
+    public void involveHttpSessionBindingListener() throws Exception {
+        Jenkins.get().setSecurityRealm(new LegacySecurityRealm());
+        rule.createWebClient().login("bob");
+    }
+}

--- a/src/it/servlet-api/src/test/java/test/ServletAPITest.java
+++ b/src/it/servlet-api/src/test/java/test/ServletAPITest.java
@@ -1,11 +1,10 @@
 package test;
 
+import hudson.security.LegacySecurityRealm;
+import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import hudson.security.LegacySecurityRealm;
-import jenkins.model.Jenkins;
 
 public class ServletAPITest {
 
@@ -15,14 +14,14 @@ public class ServletAPITest {
     /**
      * When having both Servlet APIs 3.1 and 4.0 in classpath, the following error
      * is logged on server side:
-     * 
+     *
      * <pre>
      * WARNING	o.e.jetty.server.HttpChannel#handleException: /jenkins/j_security_check
      * java.lang.AbstractMethodError: Receiver class org.eclipse.jetty.security.authentication.SessionAuthentication does not define or inherit an
      * implementation of the resolved method 'abstract void valueBound(javax.servlet.http.HttpSessionBindingEvent)' of interface
      * javax.servlet.http.HttpSessionBindingListener. at org.eclipse.jetty.server.session.Session.bindValue(Session.java:357)
      * </pre>
-     * 
+     *
      * And then on client side getting "500 Server Error for
      * http://localhost:.../jenkins/j_security_check"
      */

--- a/src/it/servlet-api/src/test/java/test/ServletAPITest.java
+++ b/src/it/servlet-api/src/test/java/test/ServletAPITest.java
@@ -19,7 +19,7 @@ public class ServletAPITest {
      * <pre>
      * WARNING	o.e.jetty.server.HttpChannel#handleException: /jenkins/j_security_check
      * java.lang.AbstractMethodError: Receiver class org.eclipse.jetty.security.authentication.SessionAuthentication does not define or inherit an
-     * implementation of the resolved emethod 'abstract void valueBound(javax.servlet.http.HttpSessionBindingEvent)' of interface
+     * implementation of the resolved method 'abstract void valueBound(javax.servlet.http.HttpSessionBindingEvent)' of interface
      * javax.servlet.http.HttpSessionBindingListener. at org.eclipse.jetty.server.session.Session.bindValue(Session.java:357)
      * </pre>
      * 


### PR DESCRIPTION
When running tests based on `JenkinsRule`, multiple servlet APIs are available from tests classpath, then causing some issues.

For example :

`javax.servlet.http.HttpSessionBindingListener` implementation class from Jetty is compiled using 4.0 (with `default`) and test execution is using 3.1 (without `default`), then causing:

```
java.lang.AbstractMethodError: Receiver class org.eclipse.jetty.security.authentication.SessionAuthentication does not define or inherit an implementation of the resolved method abstract valueBound(Ljavax/servlet/http/HttpSessionBindingEvent;)V of interface javax.servlet.http.HttpSessionBindingListener.
	at org.eclipse.jetty.server.session.Session.bindValue(Session.java:357)
```