### PR TITLE
Remove deprecated `display-info`-goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,6 @@
           <execution>
             <id>display-info</id>
             <goals>
-              <goal>display-info</goal>
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>


### PR DESCRIPTION
Fixes #702

Remove deprecated `<goal>display-info</goal>` from enforcer
According to [maven-enforcer-plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin/display-info-mojo.html) this is deprecated. And in plugins we see it somewhat double currently:
![grafik](https://user-images.githubusercontent.com/22742658/222951396-bf523a6e-fd13-449f-bd03-d9261bff77b0.png)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
