### PR TITLE
Fix flatten plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1313,7 +1313,25 @@
                 </goals>
                 <phase>process-resources</phase>
                 <configuration>
-                  <flattenMode>oss</flattenMode>
+                  <!-- flattenMode:oss does not keep dependecnyMangement or will promote all transitive dependencies to direct ones, changing resolution order -->
+                  <pomElements>
+                    <dependencyManagement>interpolate</dependencyManagement>
+                    <!-- from https://github.com/mojohaus/flatten-maven-plugin/blob/flatten-maven-plugin-1.3.0/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java#L100 -->
+                    <ciManagement>expand</ciManagement>
+                    <contributors>expand</contributors>
+                    <distributionManagement>expand</distributionManagement>
+                    <inceptionYear>expand</inceptionYear>
+                    <issueManagement>expand</issueManagement>
+                    <mailingLists>expand</mailingLists>
+                    <organization>expand</organization>
+                    <prerequisites>expand</prerequisites>
+                    <name>expand</name>
+                    <description>expand</description>
+                    <url>expand</url>
+                    <scm>expand</scm>
+                    <developers>expand</developers>
+                    <repositories>expand</repositories>
+                  </pomElements>
                   <outputDirectory>${project.build.directory}</outputDirectory>
                   <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
                 </configuration>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -15,6 +15,7 @@
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
+        <bom.version>1580.v47b_429a_c853a</bom.version>
     </properties>
 
     <repositories>
@@ -34,7 +35,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.361.x</artifactId>
-                <version>1580.v47b_429a_c853a</version>
+                <version>${bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/it/incrementals-and-plugin-bom/postbuild.groovy
+++ b/src/it/incrementals-and-plugin-bom/postbuild.groovy
@@ -1,3 +1,19 @@
 assert new File(basedir, '../../local-repo/io/jenkins/plugins/incrementals-and-plugin-bom/1.0-SNAPSHOT/incrementals-and-plugin-bom-1.0-SNAPSHOT.hpi').file
 assert new File(basedir, '../../local-repo/io/jenkins/plugins/incrementals-and-plugin-bom/1.0-rc1234.deadbeef5678/incrementals-and-plugin-bom-1.0-rc1234.deadbeef5678.hpi').file
+String pomXml = new File(basedir, '../../local-repo/io/jenkins/plugins/incrementals-and-plugin-bom/1.0-rc1234.deadbeef5678/incrementals-and-plugin-bom-1.0-rc1234.deadbeef5678.pom').text
+assert pomXml.contains('version>1.0-rc1234.deadbeef5678</version>')
+// https://github.com/jenkinsci/plugin-pom/issues/705
+// line endings need normalising
+assert pomXml.replace("\r\n", "\n").contains('''
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>1580.v47b_429a_c853a</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>'''.replace("\r\n", "\n"))
 return true


### PR DESCRIPTION
Do not strip any <dependencyManagement> section from the flattened pom.

If a plugin is using dependencyManagement to manage transitive dependencies then the version information will be lost when published.

Whilst there is a mode in the flatten plugin to promote transitive dependencies to direct dependencies this would cause different issues as the depth of dependencies would change when you are using local development and published versions.

this could also have looked at different modes like `ciFriendly` which just resolves the release version properties and their usage - this would be a bigger change to the published poms than I am prepared to test at this time.

So for now we replicate the oss mode and add in dependencyManagment

fixes #705 

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
