### PR TITLE
Remove `<mavenExecutorId>forked-path</mavenExecutorId>`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -708,7 +708,6 @@
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <mavenExecutorId>forked-path</mavenExecutorId>
           <preparationGoals>clean install</preparationGoals>
           <goals>deploy</goals>
           <arguments>${arguments}</arguments>


### PR DESCRIPTION
Fixes #683. We don't customize this in `jenkinsci/pom`, and automated release of both Jenkins core and core components seem to work fine without it, as do manual releases with `maven-release-plugin`. Seems more straightforward to get rid of this customization and follow a more standard code path that is in line with Maven defaults. I was unable to find any commit messages or tickets that explain the reason why this was customized to begin with. This change is not tested, but I believe the risk is low given that we are already using this configuration in `jenkinsci/pom`. If any issues arise, we can iterate from here or revert this change if necessary.