### PR TITLE
Remove `test-in-groovy` execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,24 +743,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <configuration>
-          <!-- gmavenplus generates into generated-sources/test by default. gmaven generated into this directory. -->
-          <testStubsOutputDirectory>${project.build.directory}/generated-test-sources/groovy-stubs</testStubsOutputDirectory>
-        </configuration>
-        <executions>
-          <execution>
-            <id>test-in-groovy</id>
-            <goals>
-              <goal>addTestSources</goal>
-              <goal>generateTestStubs</goal>
-              <goal>compileTests</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <!-- https://stackoverflow.com/a/4086207/12916 -->
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>


### PR DESCRIPTION
While there are significant usages of `gmavenplus-plugin` that remain (e.g. `pipeline-model-definition`), there are no significant plugins that build with Maven and have Groovy tests. At least running `find . -type d -name groovy | grep src.test.groovy` in my local checkout directory with the top 250 plugins turned up no results. Better to delete this unused configuration. To test this change I successfully ran `mvn clean verify` in `pipeline-model-definition-plugin` (the only significant plugin still using `gmavenplus-plugin`) with these changes.