### PR TITLE
Remove deprecated spotbugsXmlOutput setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,6 @@
                 presence of this file.
               -->
               <xmlOutput>true</xmlOutput>
-              <spotbugsXmlOutput>false</spotbugsXmlOutput>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -673,14 +673,11 @@
               <goal>check</goal>
             </goals>
             <phase>verify</phase>
-            <configuration>
-              <!--
-                Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
-                Instead, we configure this below in a profile conditionally activated based on the
-                presence of this file.
-              -->
-              <xmlOutput>true</xmlOutput>
-            </configuration>
+            <!--
+              Do not define "excludeFilterFile" here, as it will force consumers to provide a file.
+              Instead, we configure this below in a profile conditionally activated based on the
+              presence of this file.
+            -->
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Remove deprecated spotbugsXmlOutput setting

https://spotbugs.github.io/spotbugs-maven-plugin/spotbugs-mojo.html says that it is deprecated and gives no reason for the deprecation.  Since the value was faluse, it seems safe to remove the setting.

Fixes #716

https://github.com/jenkinsci/plugin-pom/issues/716 is the issue report.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
