### PR TITLE
Activate Spotless via Maven property rather than file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ See [Incrementals](https://github.com/jenkinsci/incrementals-tools) for details.
 ## Formatting
 
 To opt in to code formatting of your Java sources and Maven POM with Spotless,
-create a `.mvn_exec_spotless` file at the root of your repository and remove
-any existing Spotless configuration from your POM.
+define the `spotless.check.skip` property to `false` and remove any existing
+Spotless configuration from your POM.
 
 To format existing code, run:
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,9 @@
     -->
     <spotbugs.omitVisitors>FindReturnRef</spotbugs.omitVisitors>
 
+    <!-- Set to false to enable Spotless -->
+    <spotless.check.skip>true</spotless.check.skip>
+
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
     <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
@@ -684,6 +687,37 @@
               Instead, we configure this below in a profile conditionally activated based on the
               presence of this file.
             -->
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <configuration>
+          <java>
+            <endWithNewline />
+            <importOrder />
+            <indent>
+              <spaces>true</spaces>
+            </indent>
+            <palantirJavaFormat />
+            <removeUnusedImports />
+            <trimTrailingWhitespace />
+          </java>
+          <pom>
+            <sortPom>
+              <expandEmptyElements>false</expandEmptyElements>
+              <sortDependencies>scope,groupId,artifactId</sortDependencies>
+              <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
+              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+            </sortPom>
+          </pom>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -1427,41 +1461,9 @@
           <exists>.mvn_exec_spotless</exists>
         </file>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.diffplug.spotless</groupId>
-            <artifactId>spotless-maven-plugin</artifactId>
-            <configuration>
-              <java>
-                <endWithNewline />
-                <importOrder />
-                <indent>
-                  <spaces>true</spaces>
-                </indent>
-                <palantirJavaFormat />
-                <removeUnusedImports />
-                <trimTrailingWhitespace />
-              </java>
-              <pom>
-                <sortPom>
-                  <expandEmptyElements>false</expandEmptyElements>
-                  <sortDependencies>scope,groupId,artifactId</sortDependencies>
-                  <sortDependencyExclusions>groupId,artifactId</sortDependencyExclusions>
-                  <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-                </sortPom>
-              </pom>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <spotless.check.skip>false</spotless.check.skip>
+      </properties>
     </profile>
 
     <profile>

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>benchmark-it</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>benchmark-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/benchmark/src/test/java/benchmark/BenchmarkRunner.java
+++ b/src/it/benchmark/src/test/java/benchmark/BenchmarkRunner.java
@@ -1,5 +1,6 @@
 package benchmark;
 
+import java.util.concurrent.TimeUnit;
 import jenkins.benchmark.jmh.BenchmarkFinder;
 import org.junit.Test;
 import org.openjdk.jmh.results.format.ResultFormatType;
@@ -7,24 +8,21 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.concurrent.TimeUnit;
-
 public class BenchmarkRunner {
     @Test
     public void runThis() throws Exception {
         // number of iterations is kept to a minimum just to verify that the benchmarks work without spending extra
         // time during builds.
-        ChainedOptionsBuilder optionsBuilder =
-                new OptionsBuilder()
-                        .forks(1)
-                        .warmupIterations(1)
-                        .warmupBatchSize(1)
-                        .measurementIterations(1)
-                        .measurementBatchSize(1)
-                        .shouldFailOnError(true)
-                        .result("jmh-report.json")
-                        .timeUnit(TimeUnit.MICROSECONDS)
-                        .resultFormat(ResultFormatType.JSON);
+        ChainedOptionsBuilder optionsBuilder = new OptionsBuilder()
+                .forks(1)
+                .warmupIterations(1)
+                .warmupBatchSize(1)
+                .measurementIterations(1)
+                .measurementBatchSize(1)
+                .shouldFailOnError(true)
+                .result("jmh-report.json")
+                .timeUnit(TimeUnit.MICROSECONDS)
+                .resultFormat(ResultFormatType.JSON);
         BenchmarkFinder finder = new BenchmarkFinder(getClass());
         finder.findBenchmarks(optionsBuilder);
         new Runner(optionsBuilder.build()).run();

--- a/src/it/benchmark/src/test/java/benchmark/SampleBenchmark.java
+++ b/src/it/benchmark/src/test/java/benchmark/SampleBenchmark.java
@@ -1,15 +1,13 @@
 package benchmark;
 
+import java.io.IOException;
 import jenkins.benchmark.jmh.JmhBenchmark;
 import jenkins.benchmark.jmh.JmhBenchmarkState;
 import org.openjdk.jmh.annotations.Benchmark;
 
-import java.io.IOException;
-
 @JmhBenchmark
 public class SampleBenchmark {
-    public static class MyState extends JmhBenchmarkState {
-    }
+    public static class MyState extends JmhBenchmarkState {}
 
     @Benchmark
     public void benchmark(MyState state) throws IOException {

--- a/src/it/beta-fail/downstream/pom.xml
+++ b/src/it/beta-fail/downstream/pom.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-fail</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-fail/downstream/src/main/java/downstream/Caller.java
+++ b/src/it/beta-fail/downstream/src/main/java/downstream/Caller.java
@@ -1,5 +1,7 @@
 package downstream;
+
 import upstream.Api;
+
 public class Caller {
     static {
         Api.experimental();

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-fail</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-fail</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-fail/postbuild.groovy
+++ b/src/it/beta-fail/postbuild.groovy
@@ -1,3 +1,3 @@
-assert new File(basedir, 'build.log').text.replaceAll(/\e\[[\d;]*[^\d;]/, '').contains('[ERROR] downstream/Caller:5 upstream/Api.experimental()V is still in beta')
+assert new File(basedir, 'build.log').text.replaceAll(/\e\[[\d;]*[^\d;]/, '').contains('[ERROR] downstream/Caller:7 upstream/Api.experimental()V is still in beta')
 
 return true

--- a/src/it/beta-fail/upstream/pom.xml
+++ b/src/it/beta-fail/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-fail</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-fail</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-fail</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/beta-fail/upstream/src/main/java/upstream/Api.java
+++ b/src/it/beta-fail/upstream/src/main/java/upstream/Api.java
@@ -1,6 +1,8 @@
 package upstream;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
+
 public class Api {
     @Restricted(Beta.class)
     public static void experimental() {}

--- a/src/it/beta-just-testing/downstream/pom.xml
+++ b/src/it/beta-just-testing/downstream/pom.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-just-testing</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-just-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-just-testing/downstream/src/main/java/downstream/NotCaller.java
+++ b/src/it/beta-just-testing/downstream/src/main/java/downstream/NotCaller.java
@@ -1,3 +1,3 @@
 package downstream;
-public class NotCaller {
-}
+
+public class NotCaller {}

--- a/src/it/beta-just-testing/downstream/src/test/java/downstream/ApiTest.java
+++ b/src/it/beta-just-testing/downstream/src/test/java/downstream/ApiTest.java
@@ -1,5 +1,7 @@
 package downstream;
+
 import upstream.Api;
+
 public class ApiTest {
     static {
         Api.experimental();

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-just-testing</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-just-testing</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-just-testing/upstream/pom.xml
+++ b/src/it/beta-just-testing/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-just-testing</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-just-testing</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-just-testing</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/beta-just-testing/upstream/src/main/java/upstream/Api.java
+++ b/src/it/beta-just-testing/upstream/src/main/java/upstream/Api.java
@@ -1,6 +1,8 @@
 package upstream;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
+
 public class Api {
     @Restricted(Beta.class)
     public static void experimental() {}

--- a/src/it/beta-pass/downstream/pom.xml
+++ b/src/it/beta-pass/downstream/pom.xml
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-pass</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-    <artifactId>downstream</artifactId>
-    <packaging>hpi</packaging>
-    <properties>
-        <useBeta>true</useBeta>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-            <artifactId>upstream</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+  <artifactId>downstream</artifactId>
+  <packaging>hpi</packaging>
+  <properties>
+    <useBeta>true</useBeta>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+      <artifactId>upstream</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/beta-pass/downstream/src/main/java/downstream/Caller.java
+++ b/src/it/beta-pass/downstream/src/main/java/downstream/Caller.java
@@ -1,5 +1,7 @@
 package downstream;
+
 import upstream.Api;
+
 public class Caller {
     static {
         Api.experimental();

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>beta-pass</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <modules>
-        <module>upstream</module>
-        <module>downstream</module>
-    </modules>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>beta-pass</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>upstream</module>
+    <module>downstream</module>
+  </modules>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/beta-pass/upstream/pom.xml
+++ b/src/it/beta-pass/upstream/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins.its</groupId>
-        <artifactId>beta-pass</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
-    <artifactId>upstream</artifactId>
-    <packaging>hpi</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins.its</groupId>
+    <artifactId>beta-pass</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its.beta-pass</groupId>
+  <artifactId>upstream</artifactId>
+  <packaging>hpi</packaging>
 </project>

--- a/src/it/beta-pass/upstream/src/main/java/upstream/Api.java
+++ b/src/it/beta-pass/upstream/src/main/java/upstream/Api.java
@@ -1,6 +1,8 @@
 package upstream;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.Beta;
+
 public class Api {
     @Restricted(Beta.class)
     public static void experimental() {}

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -1,49 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>incrementals-and-plugin-bom</artifactId>
-    <version>${revision}${changelist}</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <revision>1.0</revision>
-        <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
-    </properties>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1580.v47b_429a_c853a</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>incrementals-and-plugin-bom</artifactId>
+  <version>${revision}${changelist}</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <revision>1.0</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>1580.v47b_429a_c853a</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/incrementals-and-plugin-bom/src/main/java/io/jenkins/plugins/RandomClass.java
+++ b/src/it/incrementals-and-plugin-bom/src/main/java/io/jenkins/plugins/RandomClass.java
@@ -1,4 +1,5 @@
 package io.jenkins.plugins;
+
 public class RandomClass {
     public RandomClass() {
         org.jenkinsci.plugins.workflow.steps.StepContext x = null;

--- a/src/it/incrementals-and-plugin-bom/src/test/java/io/jenkins/plugins/RandomClassTest.java
+++ b/src/it/incrementals-and-plugin-bom/src/test/java/io/jenkins/plugins/RandomClassTest.java
@@ -1,5 +1,8 @@
 package io.jenkins.plugins;
+
 import org.junit.Test;
+
 public class RandomClassTest {
-    @Test public void whatever() {}
+    @Test
+    public void whatever() {}
 }

--- a/src/it/localizer/pom.xml
+++ b/src/it/localizer/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>localizer</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-        <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>localizer</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+    <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/localizer/src/main/java/test/X.java
+++ b/src/it/localizer/src/main/java/test/X.java
@@ -5,5 +5,4 @@ public class X {
     public static String label() {
         return Messages.label();
     }
-
 }

--- a/src/it/localizer/src/test/java/test/XTest.java
+++ b/src/it/localizer/src/test/java/test/XTest.java
@@ -1,7 +1,8 @@
 package test;
 
-import org.junit.Test;
 import static org.junit.Assert.*;
+
+import org.junit.Test;
 
 public class XTest {
 
@@ -9,5 +10,4 @@ public class XTest {
     public void label() throws Exception {
         assertEquals("Whatever", X.label());
     }
-
 }

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>@project.version@</version>
-        <relativePath/>
-    </parent>
-    <groupId>org.jenkins-ci.plugins.its</groupId>
-    <artifactId>sample-plugin</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <jenkins.version>2.361.4</jenkins.version>
-    </properties>
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-    <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
-        </dependency>
-    </dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>@project.version@</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins.its</groupId>
+  <artifactId>sample-plugin</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>2.361.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.5</version>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/src/it/sample-plugin/src/main/java/test/SampleRootAction.java
+++ b/src/it/sample-plugin/src/main/java/test/SampleRootAction.java
@@ -1,7 +1,6 @@
 package test;
 
 import hudson.Extension;
-import hudson.model.InvisibleAction;
 import hudson.model.RootAction;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -12,14 +11,17 @@ public class SampleRootAction implements RootAction {
     public String getUrlName() {
         return "sample";
     }
+
     @Override
     public String getIconFileName() {
         return null;
     }
+
     @Override
     public String getDisplayName() {
         return null;
     }
+
     public HttpResponse doIndex() {
         return HttpResponses.plainText("sample served");
     }

--- a/src/it/sample-plugin/src/test/java/test/SampleRootActionTest.java
+++ b/src/it/sample-plugin/src/test/java/test/SampleRootActionTest.java
@@ -1,9 +1,10 @@
 package test;
 
-import org.apache.commons.io.IOUtils;
-import org.junit.Test;
 import static org.junit.Assert.*;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class SampleRootActionTest {
@@ -13,8 +14,12 @@ public class SampleRootActionTest {
 
     @Test
     public void smokes() throws Exception {
-        assertEquals(IOUtils.toString(SampleRootActionTest.class.getResource("expected.txt")),
-                     r.createWebClient().goTo("sample", "text/plain").getWebResponse().getContentAsString().trim());
+        assertEquals(
+                IOUtils.toString(SampleRootActionTest.class.getResource("expected.txt")),
+                r.createWebClient()
+                        .goTo("sample", "text/plain")
+                        .getWebResponse()
+                        .getContentAsString()
+                        .trim());
     }
-
 }


### PR DESCRIPTION
Thanks to the many plugin maintainers who have adopted the new configuration introduced in #733. This has allowed me to clean up the way this configuration is activated by lifting it out of a custom profile into the main section of the build. To keep it off by default I am defining `<spotless.check.skip>true</spotless.check.skip>` by default. Plugins can override this property to `<spotless.check.skip>false</spotless.check.skip>` to enable Spotless. The documentation now recommends this over the file-based activation method. The file-based activation method still works as a compatibility bridge but just sets this property. After this PR is merged, I will go through any plugins using the file-based activation method and convert them to the property method, then finally remove the file-based activation from this POM.

The only risk here is to the handful of plugins that are still defining their own configuration:

- https://github.com/jenkinsci/github-branch-source-plugin/pull/684 filed to use the standard configuration
- https://github.com/jenkinsci/git-plugin/pull/1435 filed to use the standard configuration
- https://github.com/jenkinsci/gitlab-plugin/pull/1449 to use the standard configuration
- https://github.com/jenkinsci/allure-plugin is in need of modernization in https://github.com/jenkinsci/allure-plugin/pull/325 before this can be fixed
- https://github.com/jenkinsci/artifact-repository-parameter-plugin appears unmaintained
- https://github.com/jenkinsci/gcp-secrets-manager-credentials-provider-plugin appears unmaintained
- https://github.com/jenkinsci/mattermost-plugin appears unmaintained

Since I have filed PRs to update most of these to use the standard configuration I am not worried. If for some reason the maintainers refuse to use the standard configuration then they will have to figure out how to harmonize their configuration with mine. An example of how to do this is in https://github.com/jenkinsci/additional-metrics-plugin/pull/23 where I blended in the maintainer's preference for a license header check.

As part of this PR I have also enabled Spotless for this repository's test suite and formatted any test plugins to enhance test coverage.