### PR TITLE
Remove file-based Spotless activation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1454,17 +1454,6 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>spotless-execution</id>
-      <activation>
-        <file>
-          <exists>.mvn_exec_spotless</exists>
-        </file>
-      </activation>
-      <properties>
-        <spotless.check.skip>false</spotless.check.skip>
-      </properties>
-    </profile>
 
     <profile>
       <!--  a profile that disables as much testing as possible whilst still producing the artifacts -->


### PR DESCRIPTION
Thanks to everyone who migrated to the new Spotless configuration and property-based activation mechanism, this short-lived and clunky file-based activation mechanism is no longer needed.