### PR TITLE
Replace 'hamcrest-core' with 'hamcrest'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
+        <artifactId>hamcrest</artifactId>
         <version>2.2</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
hamcrest-core is deprecated since 2019, in favor of `hamcrest` where the logic lives on since then.
Consumers are advised to replace hamcrest-x with hamcrest, if not already done.