### PR TITLE
Upgrade `palantir-java-format` to Java 21 compatible release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -707,7 +707,10 @@
             <indent>
               <spaces>true</spaces>
             </indent>
-            <palantirJavaFormat />
+            <palantirJavaFormat>
+              <!-- TODO https://github.com/diffplug/spotless/issues/1774 -->
+              <version>2.35.0</version>
+            </palantirJavaFormat>
             <removeUnusedImports />
             <trimTrailingWhitespace />
           </java>


### PR DESCRIPTION
When running `palantir-java-format` with Java 21, the current release fails with `java.lang.NoSuchMethodError: 'com.sun.tools.javac.tree.JCTree com.sun.tools.javac.tree.JCTree$JCImport.getQualifiedIdentifier()'`. This error was fixed in https://github.com/palantir/palantir-java-format/pull/909 and released in 2.35.0; however, pending https://github.com/diffplug/spotless/issues/1774 that version is not used by Spotless. This PR adopts the workaround suggested in https://github.com/diffplug/spotless/issues/1774#issuecomment-1661007774 by pinning the version until such a time that Spotless delivers version 2.35.0 by default.

### Testing done

Ran `mvn clean verify` in `text-finder` before these changes on Java 11, 17, and 21. 11 and 17 passed; 21 failed with the error reported above. After these changes, passed on 11, 17, and 21.