### PR TITLE
Make JUnit version a customizable property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <jenkins.version>2.361</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
     <jenkins-test-harness.version>2062.v3efc79721e45</jenkins-test-harness.version>
+    <junit.version>5.10.0</junit.version>
     <license-maven-plugin.version>104.v2171757ee6dd</license-maven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <localizer-maven-plugin.version>1.31</localizer-maven-plugin.version>
@@ -163,7 +164,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.10.0</version>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Mockito and Hamcrest are already customizable properties, so this makes JUnit consistent with those. The CI build should be sufficient to test this.