### PR TITLE
Remove `mrm-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -874,26 +874,6 @@
 
       <!--  the following 2 plugins are for integration tests of plugin-pom only -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>mrm-maven-plugin</artifactId>
-        <version>1.5.0</version>
-        <inherited>false</inherited>
-        <executions>
-          <execution>
-            <goals>
-              <goal>start</goal>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <propertyName>repository.proxy.url</propertyName>
-              <repositories>
-                <proxyRepo />
-              </repositories>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>3.6.0</version>
         <inherited>false</inherited>
@@ -910,9 +890,6 @@
               <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
               <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
               <settingsFile>src/it/settings.xml</settingsFile>
-              <filterProperties>
-                <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
-              </filterProperties>
             </configuration>
           </execution>
         </executions>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -22,14 +22,6 @@ under the License.
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
   xmlns="http://maven.apache.org/SETTINGS/1.1.0">
-  <mirrors>
-    <mirror>
-      <id>mrm-maven-plugin</id>
-      <name>Mock Repository Manager</name>
-      <url>@repository.proxy.url@</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
   <profiles>
     <profile>
       <id>it-repo</id>


### PR DESCRIPTION
I cannot see a reason to continue using `mrm-maven-plugin`. Based on https://www.mojohaus.org/mrm/mrm-maven-plugin/examples/invoker-tests.html it seems the reason for using it was originally

> to allow the integration tests of a Maven Plugin to be run against a test local repository thereby ensuring that the plugin does not get installed into the local repository until after the integration tests have been confirmed as passing

but I just ran `mvn clean verify` and my local `~/.m2` repository did not seem to get polluted, so I don't think this is a concern anymore now that we are configuring `maven-invoker-plugin` with `localRepositoryPath`.

For what it's worth, I asked Maven developer Tamás Cservenák to audit `maven-hpi-plugin` a few months back, and here is what he had to say:

> I'd avoid the use of mrm plugin. You already pull Jetty, simplest (and most straightforward and least error prone) is to just fire up Jetty to serve files from somewhere as "remote repository" as in that case you are 100% in control of what is being served, while with MRM you are not.