### PR TITLE
Revert "Remove `mrm-maven-plugin`"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -874,6 +874,26 @@
 
       <!--  the following 2 plugins are for integration tests of plugin-pom only -->
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>mrm-maven-plugin</artifactId>
+        <version>1.5.0</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <goals>
+              <goal>start</goal>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <propertyName>repository.proxy.url</propertyName>
+              <repositories>
+                <proxyRepo />
+              </repositories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <version>3.6.0</version>
         <inherited>false</inherited>
@@ -890,6 +910,9 @@
               <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
               <localRepositoryPath>${basedir}/target/local-repo</localRepositoryPath>
               <settingsFile>src/it/settings.xml</settingsFile>
+              <filterProperties>
+                <repository.proxy.url>${repository.proxy.url}</repository.proxy.url>
+              </filterProperties>
             </configuration>
           </execution>
         </executions>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -22,6 +22,14 @@ under the License.
 <settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd"
   xmlns="http://maven.apache.org/SETTINGS/1.1.0">
+  <mirrors>
+    <mirror>
+      <id>mrm-maven-plugin</id>
+      <name>Mock Repository Manager</name>
+      <url>@repository.proxy.url@</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
   <profiles>
     <profile>
       <id>it-repo</id>


### PR DESCRIPTION
Reverting jenkinsci/plugin-pom#828, since I didn't notice in the original build that it introduced a bunch of new warnings:

```
13:48:22  [INFO] [INFO] Artifact org.apache.maven:maven-parent:pom:39 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
13:48:22  [INFO] [INFO] Artifact org.apache.maven:maven-parent:pom:39 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
13:48:22  [INFO] [INFO] Artifact org.apache:apache:pom:29 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
13:48:22  [INFO] [INFO] Artifact org.apache:apache:pom:29 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
13:48:22  [INFO] [INFO] Artifact org.codehaus.plexus:plexus-utils:pom:3.4.2 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
13:48:22  [INFO] [INFO] Artifact org.codehaus.plexus:plexus-utils:pom:3.4.2 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context, verifying that is downloadable from [central (https://repo.maven.apache.org/maven2, default, releases)]
```