### PR TITLE
Add PowerMock to banned dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,24 @@
                     <!-- CVE-2021-44228 -->
                     <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude>
 
+                    <!-- PowerMock has been abandoned and does not work on newer Java versions. -->
+                    <exclude>org.powermock:powermock-api-easymock</exclude>
+                    <exclude>org.powermock:powermock-api-mockito2</exclude>
+                    <exclude>org.powermock:powermock-api-support</exclude>
+                    <exclude>org.powermock:powermock-classloading-base</exclude>
+                    <exclude>org.powermock:powermock-classloading-objenesis</exclude>
+                    <exclude>org.powermock:powermock-classloading-xstream</exclude>
+                    <exclude>org.powermock:powermock-core</exclude>
+                    <exclude>org.powermock:powermock-module-javaagent</exclude>
+                    <exclude>org.powermock:powermock-module-junit4</exclude>
+                    <exclude>org.powermock:powermock-module-junit4-common</exclude>
+                    <exclude>org.powermock:powermock-module-junit4-legacy</exclude>
+                    <exclude>org.powermock:powermock-module-junit4-rule</exclude>
+                    <exclude>org.powermock:powermock-module-junit4-rule-agent</exclude>
+                    <exclude>org.powermock:powermock-module-testng</exclude>
+                    <exclude>org.powermock:powermock-module-testng-agent</exclude>
+                    <exclude>org.powermock:powermock-module-testng-common</exclude>
+
                     <!-- Jenkins Test Harness is based on JUnit. Adding TestNG dependency would disable some of its functionality. -->
                     <exclude>org.testng:testng</exclude>
                   </excludes>


### PR DESCRIPTION
PowerMock tends to wreak havoc when it is on the classpath at the same time as Mockito in newer Java versions, so ban this dependency. I have not banned `org.powermock:powermock-reflect` since it is actually safe and some plugins (like Blue Ocean) depend on it. But I have banned every other PowerMock artifact.

### Testing done

I tested this in context in a plugin that used `powermock-reflect`. Attempting to add another PowerMock package caused (as expected):

```
Rule 4: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
org.jenkins-ci.plugins:build-blocker-plugin:hpi:1.7.10-SNAPSHOT
   org.powermock:powermock-module-junit4:jar:2.0.9 <--- banned via the exclude/include list
```

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
