### PR TITLE
Define `maven.compiler.testRelease` in terms of `maven.compiler.release`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.testRelease>11</maven.compiler.testRelease>
+    <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <!-- Filled in by maven-hpi-plugin from the MANIFEST.MF entry in jenkins.war, but we provide a default value for the benefit of IDEs. -->


### PR DESCRIPTION
While writing https://github.com/jenkinsci/jep/pull/400#issuecomment-1789790624 I realized that there was no good reason not to define `maven.compiler.testRelease` in terms of `maven.compiler.release`. When defined in this way, a consumer that wants to use two different values can still do so, but a consumer that simply wants to change bytecode generation from Java 11 bytecode to e.g. Java 17 bytecode now only has to change one property instead of two, which is a net benefit. As of this PR, there is just one occurrence of "11" in the POM, which is the `maven.compiler.release` property, and this now becomes the only knob that needs to be tuned to decide on which bytecode should be generated.

### Testing done

In `text-finder-plugin` I applied

```xml
diff --git a/pom.xml b/pom.xml
index 51a56f5..17b6a0d 100644
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.75</version>
+    <version>4.76-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -48,6 +48,7 @@
     <jenkins.version>2.387.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotless.check.skip>false</spotless.check.skip>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>
```

and verified that I could open the project in an IDE, write code with Java 17 language features in a test, and run the test successfully both in the IDE and on the command-line.