### PR TITLE
Revert "Bump com.github.spotbugs:spotbugs-maven-plugin from 4.7.3.6 to 4.8.1.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
     <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <mockito.version>5.7.0</mockito.version>
-    <spotbugs-maven-plugin.version>4.8.1.0</spotbugs-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.7.3.6</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.40.0</spotless-maven-plugin.version>
     <stapler-maven-plugin.version>175.vff879c6738b_6</stapler-maven-plugin.version>
 


### PR DESCRIPTION
Reverts jenkinsci/plugin-pom#856 because this new version results in dozens of noisy SpotBugs violations of questionable value.