### PR TITLE
Ban Jenkins test harness in compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,9 @@
                     <!-- CVE-2021-44228 -->
                     <exclude>org.apache.logging.log4j:*:(,2.15.0-rc1]</exclude>
 
+                    <!-- The Jenkins test harness wreaks havoc in production, so ensure it is in test scope. -->
+                    <exclude>org.jenkins-ci.main:jenkins-test-harness:*:jar:compile</exclude>
+
                     <!-- PowerMock has been abandoned and does not work on newer Java versions. -->
                     <exclude>org.powermock:powermock-api-easymock</exclude>
                     <exclude>org.powermock:powermock-api-mockito2</exclude>


### PR DESCRIPTION
See [JENKINS-65650](https://issues.jenkins.io/browse/JENKINS-65650), [JENKINS-66060](https://issues.jenkins.io/browse/JENKINS-66060), and [JENKINS-72353](https://issues.jenkins.io/browse/JENKINS-72353). Prevent a common mistake by turning it into a compilation error.

### Testing done

Verified that `build-pipeline-plugin` could be compiled in its current (broken) state before this PR and threw an error after this PR, and that the error went away after ensuring the Jenkins test harness was in test scope.