### PR TITLE
[JENKINS-72956] Skip Spotless in quick-build profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1446,6 +1446,7 @@
         <!-- we can not use maven.test.skip because we may be producing a test jar -->
         <skipTests>true</skipTests>
         <spotbugs.skip>true</spotbugs.skip>
+        <spotless.skip>true</spotless.skip>
         <enforcer.skip>true</enforcer.skip>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
         <invoker.skip>true</invoker.skip>


### PR DESCRIPTION
Corresponds to https://github.com/jenkinsci/pom/pull/537 per https://github.com/jenkinsci/pom/pull/537#pullrequestreview-1980676329

## Testing

Used a local snapshot of this change on `matrix-auth` plugin with a change that would fail Spotless in the released plugin POM 4.80 with `-Pquick-build`, passed after.