### PR TITLE
Suppress Javadoc timestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,7 @@
             </links>
             <doclint>all,-missing</doclint>
             <locale>en_US</locale>
+            <notimestamp>true</notimestamp>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Suppresses the timestamp, which is hidden in an HTML comment in the generated HTML near the top of each page. Needed for #919. If the project has the property `project.build.outputTimestamp`, the value is true by default, but we might not have that property set when doing reproducible builds using https://github.com/jenkinsci/incrementals-tools/pull/104.

### Testing done

Built Text Finder with these changes; no regressions generating Javadoc.