### PR TITLE
Remove dead code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,12 +209,6 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-core</artifactId>
         <version>${jenkins.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
@@ -227,12 +221,6 @@
         <version>${jenkins.version}</version>
         <type>executable-war</type>
         <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
I removed these exclusions and verified that `mvn dependency:tree -Dverbose` in a plugin remained the same before and after this PR against both weekly and the earliest supported version (2.361), proving these lines of code are dead code.