### PR TITLE
Revert "Bump org.jenkins-ci.tools:maven-hpi-plugin from 3.57 to 3.58"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <frontend-version>1.15.0</frontend-version>
     <gmavenplus-plugin.version>3.0.2</gmavenplus-plugin.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <hpi-plugin.version>3.58</hpi-plugin.version>
+    <hpi-plugin.version>3.57</hpi-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
     <incrementals-plugin.version>1.8</incrementals-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>


### PR DESCRIPTION
Reverts jenkinsci/plugin-pom#1001

This release requires Java 17 or newer, while the plugin parent POM still supports Java 11.