### PR TITLE
[JENKINS-73339] Require Java 17 and Jetty 12 (EE 9) for plugin development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     ignore:
-      # TODO https://github.com/jenkinsci/plugin-pom/issues/936 delete when baseline is 2.459+ -->
-      - dependency-name: "jakarta.servlet:jakarta.servlet-api"
-        versions: [">=5.0.0"]
       - dependency-name: "org.jenkins-ci.main:jenkins-bom"
       - dependency-name: "org.jenkins-ci.main:jenkins-core"
       - dependency-name: "org.jenkins-ci.main:jenkins-war"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It provides a common build configuration for all Jenkins plugins.
 
 ## Requirements
 
+Since version 4.89, the plugin parent POM requires Jenkins 2.477 or newer and JDK 17 or newer.
 Since version 4.52, the plugin parent POM requires Jenkins 2.361 or newer and JDK 11 or newer.
 Since version 4.40, the plugin parent POM supports Java 17.
 
@@ -88,56 +89,6 @@ end with the word `Benchmark`. For example, `FooBenchmark` and `BenchmarkFoo` wi
 be detected when using `-Dbenchmark`, however, `FooBar` will be ignored.
 
 See also: [documentation for JMH benchmarks](https://github.com/jenkinsci/jenkins-test-harness/blob/master/docs/jmh-benchmarks.adoc)
-
-## Temporary workarounds
-
-### Running tests with Jetty 12 (EE 8)
-
-To run tests with Jetty 12 (EE 8) with Jenkins 2.471 or older,
-add the following to `pom.xml`:
-
-```xml
-<!-- TODO JENKINS-73339 until in parent POM -->
-<jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>
-<maven.compiler.testRelease>17</maven.compiler.testRelease>
-```
-
-This will not be necessary in a future release of the plugin parent POM that requires Jenkins 2.472 or newer.
-
-### Running the entire build with Jetty 12 (EE 8):
-
-To run the entire build with Jetty 12 (EE 8) and require Jenkins 2.472 or newer,
-add the following to `pom.xml` (adjusting your BOM version as necessary):
-
-```xml
-<jenkins.version>2.472</jenkins.version>
-<!-- TODO JENKINS-73339 until in parent POM -->
-<jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>
-<maven.compiler.release>17</maven.compiler.release>
-```
-
-This will not be necessary in a future release of the plugin parent POM that requires Jenkins 2.472 or newer.
-
-### Running the entire build with Jetty 12 (EE 9):
-
-To run the entire build with Jetty 12 (EE 9),
-first follow the steps in the preceding section,
-then add the following to `pom.xml`:
-
-```xml
-<dependencyManagement>
-  <dependencies>
-    <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>5.0.0</version>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
-```
-
-This will not be necessary in a future release of the plugin parent POM that requires Jetty 12 EE 9 or newer.
 
 ## Javadoc
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
     <!-- Generate metadata for reflection on method parameters -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -74,13 +74,13 @@
     <frontend-version>1.15.1</frontend-version>
     <gmavenplus-plugin.version>3.0.2</gmavenplus-plugin.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <hpi-plugin.version>3.57</hpi-plugin.version>
+    <hpi-plugin.version>3.58</hpi-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
     <incrementals-plugin.version>1.8</incrementals-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <jenkins.version>2.361</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <jenkins-bom.version>${jenkins.version}</jenkins-bom.version>
-    <jenkins-test-harness.version>2225.2230.v6210cb_b_827f9</jenkins-test-harness.version>
+    <jenkins-test-harness.version>2289.vfd344a_6d1660</jenkins-test-harness.version>
     <junit.version>5.11.0</junit.version>
     <license-maven-plugin.version>157.vcd037a_d79631</license-maven-plugin.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
@@ -178,13 +178,6 @@
         <version>${mockito.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <!-- used in JTH and jenkins core > 2.x -->
-        <!-- TODO https://github.com/jenkinsci/plugin-pom/issues/936 delete when baseline is 2.459+ -->
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>jakarta.servlet-api</artifactId>
-        <version>4.0.4</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -596,57 +589,6 @@
                 <requireUpperBoundDeps>
                   <excludes>
                     <exclude>com.google.code.findbugs:jsr305</exclude>
-                    <!--
-                      Work around the following require upper bound dependencies error on 2.426.x:
-
-                        Require upper bound dependencies error for org.ow2.asm:asm-tree:9.6 paths to dependency are:
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-tree:9.6 (managed) ← org.ow2.asm:asm-tree:9.7
-                        and
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-analysis:9.6 (managed) ← org.ow2.asm:asm-analysis:9.7
-                              +-org.ow2.asm:asm-tree:9.6 (managed) ← org.ow2.asm:asm-tree:9.6
-                        and
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-commons:9.6 (managed) ← org.ow2.asm:asm-commons:9.7
-                              +-org.ow2.asm:asm-tree:9.6 (managed) ← org.ow2.asm:asm-tree:9.6
-                        and
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-util:9.6 (managed) ← org.ow2.asm:asm-util:9.7
-                              +-org.ow2.asm:asm-tree:9.6 (managed) ← org.ow2.asm:asm-tree:9.6
-                        ,
-                        Require upper bound dependencies error for org.ow2.asm:asm-analysis:9.6 paths to dependency are:
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-analysis:9.6 (managed) ← org.ow2.asm:asm-analysis:9.7
-                        and
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-util:9.6 (managed) ← org.ow2.asm:asm-util:9.7
-                              +-org.ow2.asm:asm-analysis:9.6 (managed) ← org.ow2.asm:asm-analysis:9.6
-                        ,
-                        Require upper bound dependencies error for org.ow2.asm:asm-commons:9.6 paths to dependency are:
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-commons:9.6 (managed) ← org.ow2.asm:asm-commons:9.7
-                        ,
-                        Require upper bound dependencies error for org.ow2.asm:asm-util:9.6 paths to dependency are:
-                        +-org.jenkins-ci.plugins:jacoco:3.3.6
-                          +-io.jenkins.plugins:asm-api:9.7-33.v4d23ef79fcc8
-                            +-org.ow2.asm:asm-util:9.6 (managed) ← org.ow2.asm:asm-util:9.7
-                        ]
-
-                      In the long term, this ought to be mitigated by removing ASM from Jenkins core.
-                    -->
-                    <exclude>org.ow2.asm:asm</exclude>
-                    <exclude>org.ow2.asm:asm-analysis</exclude>
-                    <exclude>org.ow2.asm:asm-commons</exclude>
-                    <exclude>org.ow2.asm:asm-tree</exclude>
-                    <exclude>org.ow2.asm:asm-util</exclude>
                   </excludes>
                 </requireUpperBoundDeps>
               </rules>

--- a/src/it/benchmark/pom.xml
+++ b/src/it/benchmark/pom.xml
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
   </properties>
   <repositories>
     <repository>

--- a/src/it/beta-fail/pom.xml
+++ b/src/it/beta-fail/pom.xml
@@ -16,7 +16,7 @@
     <module>downstream</module>
   </modules>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>

--- a/src/it/beta-just-testing/pom.xml
+++ b/src/it/beta-just-testing/pom.xml
@@ -16,7 +16,7 @@
     <module>downstream</module>
   </modules>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>

--- a/src/it/beta-pass/pom.xml
+++ b/src/it/beta-pass/pom.xml
@@ -16,7 +16,7 @@
     <module>downstream</module>
   </modules>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>

--- a/src/it/cd-plugin/pom.xml
+++ b/src/it/cd-plugin/pom.xml
@@ -14,7 +14,7 @@
   <name>CD plugin</name>
   <description>CD description</description>
   <properties>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <changelist>999999-SNAPSHOT</changelist>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/it/incrementals-and-plugin-bom/pom.xml
+++ b/src/it/incrementals-and-plugin-bom/pom.xml
@@ -14,15 +14,15 @@
   <properties>
     <revision>1.0</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>1580.v47b_429a_c853a</version>
+        <artifactId>bom-2.462.x</artifactId>
+        <version>3358.vea_fa_1f41504d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/it/localizer/pom.xml
+++ b/src/it/localizer/pom.xml
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
   </properties>

--- a/src/it/sample-plugin/pom.xml
+++ b/src/it/sample-plugin/pom.xml
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
   <dependencies>

--- a/src/it/servlet-api/pom.xml
+++ b/src/it/servlet-api/pom.xml
@@ -12,7 +12,7 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <properties>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.477</jenkins.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
In draft until EE 9 is delivered in an LTS release.

### Testing done

`mvn clean verify`

Fixes #936
Fixes #918