### PR TITLE
Revert "Do not ignore `mvntest` failure"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1184,7 +1184,6 @@
                 <configuration>
                   <!-- The package.json must define an "mvntest" script -->
                   <arguments>run mvntest</arguments>
-                  <testFailureIgnore>false</testFailureIgnore>
                 </configuration>
               </execution>
 
@@ -1253,7 +1252,6 @@
                 <configuration>
                   <!-- The package.json must define an "mvntest" script -->
                   <arguments>run mvntest</arguments>
-                  <testFailureIgnore>false</testFailureIgnore>
                 </configuration>
               </execution>
 


### PR DESCRIPTION
Reverts jenkinsci/plugin-pom#1008

This was incorrect, for the proper implementation see https://github.com/jenkinsci/pipeline-graph-view-plugin/pull/428

(I'm working on a doc update)