### PR TITLE
Fix doc since marker files are dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ If you want to add `npm` or `yarn` to your plugin, you can do so by creating a m
 For npm:
 
 ```bash
-touch mvn_exec_node
+touch .mvn_exec_node
 ```
 
 For yarn:
 
 ```bash
-touch mvn_exec_yarn
+touch .mvn_exec_yarn
 ```
 
 You need to add corresponding properties to your `pom.xml` and set them to valid values:


### PR DESCRIPTION
The documentation for the marker files missed the leading dot.

They were introduced by #1016.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
