### PR TITLE
Enable `toggleOffOn` feature for spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,6 +681,7 @@
             </indent>
             <palantirJavaFormat />
             <removeUnusedImports />
+            <toggleOffOn />
             <trimTrailingWhitespace />
           </java>
           <pom>


### PR DESCRIPTION
I ran into some cases where the formatting of `com.diffplug.spotless:spotless-maven-plugin` simply did not produce satisfying results.
There is a [feature](https://github.com/diffplug/spotless/tree/main/plugin-maven#spotlessoff-and-spotlesson) that allows comments to toggle spotless formatting on and off (disabled by default):

```java
  public void doNotFormatThisPlease() {
    // spotless:off
   ...
    // spotless:on
  }
```

While I can override the config in my plugin `pom.xml` I don't see a reason to not enable the feature by default here.

### Testing done

Manually verified that changes have no impact if the feature is not being used.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
