### PR TITLE
Add `bridge-method-injector` support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook}</argLine>
 
     <access-modifier-checker.version>1.34</access-modifier-checker.version>
+    <bridge-method-injector.version>1.30</bridge-method-injector.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <frontend-version>1.15.1</frontend-version>
     <gmavenplus-plugin.version>4.1.1</gmavenplus-plugin.version>
@@ -490,6 +491,11 @@
           <version>${access-modifier-checker.version}</version>
         </plugin>
         <plugin>
+          <groupId>com.infradna.tool</groupId>
+          <artifactId>bridge-method-injector</artifactId>
+          <version>${bridge-method-injector.version}</version>
+        </plugin>
+        <plugin>
           <groupId>io.jenkins.tools.maven</groupId>
           <artifactId>stapler-maven-plugin</artifactId>
           <version>${stapler-maven-plugin.version}</version>
@@ -797,6 +803,17 @@
           <runOrder>alphabetical</runOrder>
           <reuseForks>false</reuseForks>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.infradna.tool</groupId>
+        <artifactId>bridge-method-injector</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>io.jenkins.tools.maven</groupId>


### PR DESCRIPTION
This PR fixes #903.

This PR adds support for the bridge-method-injector plugin in the Jenkins plugin-pom. By including it, any Jenkins plugin that uses this parent pom will automatically inherit the configuration for this plugin

### Testing done

- Ran **mvn clean verify** on the plugin-pom project to ensure the built completed successfully
- To verify the functionality, I tested a downstream plugin(Display URL API Plugin), by updating its parent pom to the locally built one. The plugin built successfully using the updated parent
- Asserted that the downstream project’s effective pom (**mvn help:effective-pom**) includes the bridge-method-injector plugin(inherited from the parent)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
