### PR TITLE
Prepare for JEP 451

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
     <releaseProfiles />
     <arguments />
-    <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook}</argLine>
+    <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook} @{jenkins.javaAgent}</argLine>
 
     <access-modifier-checker.version>1.35</access-modifier-checker.version>
     <bridge-method-injector.version>1.31</bridge-method-injector.version>
@@ -503,6 +503,37 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>properties</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <target>
+                <condition else="" property="jenkins.javaAgent" value="-javaagent:${org.mockito:mockito-core:jar}">
+                  <isset property="org.mockito:mockito-core:jar" />
+                </condition>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>


### PR DESCRIPTION
### Context

See [JEP 451](https://openjdk.org/jeps/451).

### Problem

While testing `ec2-plugin` recently, I saw

```
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (/home/basil/.m2/repository/net/bytebuddy/byte-buddy-agent/1.15.11/byte-buddy-agent-1.15.11.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

### Solution

Following the documentation, add

> To add Mockito as an agent to Maven's surefire plugin, the following configuration is needed:
>
>```xml
> <plugin>
>     <groupId>org.apache.maven.plugins</groupId>
>     <artifactId>maven-dependency-plugin</artifactId>
>     <executions>
>         <execution>
>             <goals>
>                 <goal>properties</goal>
>             </goals>
>         </execution>
>     </executions>
> </plugin>
> <plugin>
>     <groupId>org.apache.maven.plugins</groupId>
>     <artifactId>maven-surefire-plugin</artifactId>
>     <configuration>
>         <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
>     </configuration>
> </plugin>
>```

### Implementation

To support usage in plugins that use Mockito and those that don't, use late binding in the plugin parent POM (@ rather than $). Use Ant to coalesce the value into either `-javaagent:<jar>` or the empty string to allow for usage when Mockito is present and when it is absent.

### Testing done

- Before this PR, no warning in `text-finder` and warning in `ec2`.
- After this PR, no warning in either, and tests still pass in both.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
