### PR TITLE
Give Java agent task a unique ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -780,6 +780,7 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <id>configureJavaAgent</id>
             <goals>
               <goal>run</goal>
             </goals>


### PR DESCRIPTION
Amends #1130. Noticed when trying to upgrade `job-dsl` to the latest plugin parent POM. `job-dsl` had its own Ant task that was overwriting the one from the parent POM, so the task in the parent POM was never running and the JVM failed to start due to a missing Java agent configuration. By giving the task a unique ID in the parent POM, we ensure that legitimate downstream configuration in plugins doesn't overwrite it.

### Testing done

Verified that the upgrade in `job-dsl` failed before this PR and passed with it.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
