### PR TITLE
Declare formatter version to avoid spotless choosing a version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -688,7 +688,11 @@
             <indent>
               <spaces>true</spaces>
             </indent>
-            <palantirJavaFormat />
+            <palantirJavaFormat>
+              <!-- Declare version so that spotless does not choose a version based on JDK version -->
+              <!-- https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 -->
+              <version>2.67.0</version>
+            </palantirJavaFormat>
             <removeUnusedImports />
             <toggleOffOn />
             <trimTrailingWhitespace />


### PR DESCRIPTION
## Declare formatter version to avoid spotless choosing a version

https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 indicates that spotless chooses a formatter version based on the JDK running the formatting process.  The spotless maintainer recommends that we declare a formatter version explicitly so that the formatter won't change based on the JDK version.

### Testing done

```
MAVEN_OPTS=-Djansi.force=true mvn -B -Dstyle.color=always -ntp clean verify
```

In the [winstone repository](https://github.com/MarkEWaite/winstone/commits/explore-palantir-format-version/) (where we saw the issue):

Reverted the change that made the formatting independent of Java version in b95111923002d82598d4d85f67f40fa6170dda5e and then added explicit spotless version definition to the pom file so that I could confirm that changing Java versions does not change the formatting.

https://github.com/MarkEWaite/winstone/commit/78ea965783b5be03f143cb12ba30897581273dd1 has the details

```
. ~/bin/use_java17
mvn spotless:apply
git status
```

```
. ~/bin/use_java21
mvn spotless:apply
git status
```

The formatting was unchanged in both cases.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
