### PR TITLE
Use palantir Java format 2.72.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -691,7 +691,7 @@
             <palantirJavaFormat>
               <!-- Declare version so that spotless does not choose a version based on JDK version -->
               <!-- https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 -->
-              <version>2.67.0</version>
+              <version>2.72.0</version>
             </palantirJavaFormat>
             <removeUnusedImports />
             <toggleOffOn />


### PR DESCRIPTION
## Use palantir Java format 2.72.0

Most recent release of the formatter.

https://github.com/palantir/palantir-java-format/releases lists the releases.

### Testing done

* Confirmed that `mvn clean verify` passes
* Confirmed that 10+ plugins do not alter formatting with Java 21 when using this version

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
