### PR TITLE
Use Palantir Java Format 2.73.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -691,7 +691,7 @@
             <palantirJavaFormat>
               <!-- Declare version so that spotless does not choose a version based on JDK version -->
               <!-- https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 -->
-              <version>2.72.0</version>
+              <version>2.73.0</version>
             </palantirJavaFormat>
             <removeUnusedImports />
             <toggleOffOn />


### PR DESCRIPTION
## Use Palantir Java Format 2.73.0

[Palantir Java Format 2.73.0](https://github.com/palantir/palantir-java-format/releases/tag/2.73.0) released last week.

The git client plugin use of `spotless` needs the Palantir Java Format upgrade to 2.73.0 in order to run `spotless` with Java 25.  The Palantir Java Format upgrade does not seem to be required for Jenkins core to run `spotless` with Java 25.

Matching pull request in the core pom:

* https://github.com/jenkinsci/pom/pull/702

### Testing done

Confirmed that `mvn spotless:apply` fails with Java 25 EA build 28 on git client plugin without this change.

Confirmed that `mvn spotless:apply` succeeds with Java 25 EA build 28 on git client plugin with this change.

Confirmed that `mvn spotless:apply` makes no formatting changes in git client plugin with this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
