### PR TITLE
Upgrade `bridge-method-injector` from 1.31 to 1.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook} @{jenkins.javaAgent}</argLine>
 
     <access-modifier-checker.version>1.35</access-modifier-checker.version>
-    <bridge-method-injector.version>1.31</bridge-method-injector.version>
+    <bridge-method-injector.version>1.32</bridge-method-injector.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
     <frontend-version>1.15.1</frontend-version>
     <gmavenplus-plugin.version>4.2.1</gmavenplus-plugin.version>
@@ -494,7 +494,7 @@
           <version>${access-modifier-checker.version}</version>
         </plugin>
         <plugin>
-          <groupId>com.infradna.tool</groupId>
+          <groupId>io.jenkins.tools</groupId>
           <artifactId>bridge-method-injector</artifactId>
           <version>${bridge-method-injector.version}</version>
         </plugin>
@@ -813,7 +813,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.infradna.tool</groupId>
+        <groupId>io.jenkins.tools</groupId>
         <artifactId>bridge-method-injector</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
With https://github.com/jenkinsci/bridge-method-injector/pull/124 comes a new Maven Group ID.