### PR TITLE
Bump org.jenkins-ci.tools:maven-hpi-plugin from 3.66 to 3.1746.v2e9fe7dc4d95

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <frontend-version>1.15.1</frontend-version>
     <gmavenplus-plugin.version>4.2.1</gmavenplus-plugin.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <hpi-plugin.version>3.66</hpi-plugin.version>
+    <hpi-plugin.version>3.1746.v2e9fe7dc4d95</hpi-plugin.version>
     <incrementals-enforce-minimum.version>1.0-beta-4</incrementals-enforce-minimum.version>
     <incrementals-plugin.version>1.8</incrementals-plugin.version>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/maven-hpi-plugin/pull/771. Dependabot will file this eventually, but I'd like to get a release out to be able to use the new options in some plugins and in https://github.com/jenkinsci/archetypes/pull/844.

Part of https://github.com/jenkinsci/maven-hpi-plugin/issues/557.

### Testing done

Untested

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
