### PR TITLE
Ban Junit3 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,7 +676,10 @@
               <rules>
                 <RestrictImports>
                   <reason>Use JUnit 5 (org.junit.jupiter.*)</reason>
-                  <bannedImport>org.junit.**</bannedImport>
+                  <bannedImports>
+                      <bannedImport>junit.**</bannedImport>
+                      <bannedImport>org.junit.**</bannedImport>
+                  </bannedImports>
                   <allowedImports>
                     <allowedImport>org.junit.jupiter.**</allowedImport>
                     <allowedImport>org.junit.platform.**</allowedImport>

--- a/src/it/ban-junit4-fail/src/test/java/banjunit4/BanJUnit4FailTest.java
+++ b/src/it/ban-junit4-fail/src/test/java/banjunit4/BanJUnit4FailTest.java
@@ -8,5 +8,6 @@ public class BanJUnit4FailTest {
     @Test
     public void thisFails() {
         assertTrue(true);
+        junit.framework.Assert.assertFalse(fale);
     }
 }


### PR DESCRIPTION
This change bans `junit.**` imports. See #1178 for context.

These imports are originally for JUnit3 but some are also included in the JUnit 4 dependencies.

### Testing done

`mvn clean verify -Dinvoker.test=ban-junit4-pass,ban-junit4-fail`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
