### PR TITLE
Remove explicit JUnit 4 dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can set up `mvn spotless:apply` to run automatically (in `validate` phase) f
 
 ## Additional Checks
 
-You can set the `ban-junit4-imports.skip` property to `false` if your tests are written with JUnit 5 (Jupiter) and you want to ensure that no JUnit 4 imports are used in your plugin.
+You can set the `ban-junit4-imports.skip` property to `false` if your tests are written with JUnit Jupiter and you want to ensure that no JUnit 4 imports are used in your plugin.
 This will prevent imports of JUnit 4 classes in your code to ensure newly added or improved tests do not reintroduce JUnit 4 (e.g., out of habit or from IDE import autocompletion).
 Note that this will only address _imports_ of JUnit 4 in your code, and not uses from dependencies, or even use of fully qualified class names.
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,11 +217,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
         <version>${hamcrest.version}</version>
@@ -680,7 +675,7 @@
             <configuration>
               <rules>
                 <RestrictImports>
-                  <reason>Use JUnit 5 (org.junit.jupiter.*)</reason>
+                  <reason>Use JUnit Jupiter (org.junit.jupiter.*)</reason>
                   <bannedImports>
                     <bannedImport>junit.**</bannedImport>
                     <bannedImport>org.junit.**</bannedImport>

--- a/src/it/ban-junit4-fail/postbuild.groovy
+++ b/src/it/ban-junit4-fail/postbuild.groovy
@@ -4,7 +4,7 @@ assert !hpi.exists()
 
 // Because of banned imports
 def log = new File(basedir, 'build.log')
-assert log.text.contains('Reason: Use JUnit 5 (org.junit.jupiter.*)')
+assert log.text.contains('Reason: Use JUnit Jupiter (org.junit.jupiter.*)')
 assert log.text.contains('org.junit.Test')
 assert log.text.contains('(Line: 3, Matched by: org.junit.**)')
 assert log.text.contains('static org.junit.Assert.assertTrue')


### PR DESCRIPTION
Removes the explicit JUnit 4 dependency declaration. 
It is still transitively pulled through `junit-vintage-engine` so there is no reason to declare it again.

This change could be considered `breaking` as consumers that have a hard dependency on `junit:junit` would likely fail to build (e.g. https://github.com/jenkinsci/xshell-plugin/pull/260). Otherwise there should be no side-effects, meaning plugins that still use JUnit 4 (but don't declare it) are not affected.

I want to take this measure to push the JUnit Jupiter migration as discussed on the Contributor Summit 2026.

### Testing done

Tested locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed