### PR TITLE
ban deprecated stapler and javax.servlet classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,9 @@
     <!-- Set to false to enable enforcer banning org.apache.commons.lang.* imports -->
     <ban-commons-lang-2.skip>true</ban-commons-lang-2.skip>
 
+    <!-- Set to false to enable enforcer banning StaplerRequest, StaplerResponse and javax.servlet.* imports -->
+    <ban-deprecated-stapler.skip>true</ban-deprecated-stapler.skip>
+
     <!-- Whether to skip tests during release phase (they are executed in the prepare phase). -->
     <release.skipTests>true</release.skipTests>
     <!-- By default we do not create *-tests.jar. Set to false to allow other plugins to depend on test utilities in yours, using <classifier>tests</classifier>. -->
@@ -717,6 +720,26 @@
                 </RestrictImports>
               </rules>
               <skip>${ban-commons-lang-2.skip}</skip>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check-deprecated-stapler-imports</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <rules>
+                <RestrictImports>
+                  <reason>Use Deprecated Stapler classes</reason>
+                  <bannedImports>
+                    <bannedImport>org.kohsuke.stapler.StaplerRequest</bannedImport>
+                    <bannedImport>org.kohsuke.stapler.StaplerResponse</bannedImport>
+                    <bannedImport>javax.servlet.**</bannedImport>
+                  </bannedImports>
+                </RestrictImports>
+              </rules>
+              <skip>${ban-deprecated-stapler.skip}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
While evaluating new plugin hosting requests I notice that sometimes StaplerRequest, StaplerResponse and javax.servlet.*  are still used.
Would be good that catch that earlier so I don't need to manually look for these.

Guarded by a property so that it is not enabled by default.
The new property should be enforced for new plugins, added to the archetype and plugin modernizer I think

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
