### PR TITLE
Suppress sun.misc.Unsafe and JNA native-access warnings on Java 23+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
 
     <releaseProfiles />
     <arguments />
-    <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook} @{jenkins.javaAgent}</argLine>
+    <jenkins.java23Plus />
+    <argLine>-Xms768M -Xmx768M -XX:+HeapDumpOnOutOfMemoryError -XX:+TieredCompilation -XX:TieredStopAtLevel=1 @{jenkins.addOpens} @{jenkins.insaneHook} @{jenkins.javaAgent} @{jenkins.java23Plus}</argLine>
 
     <access-modifier-checker.version>1.35</access-modifier-checker.version>
     <bridge-method-injector.version>1.32</bridge-method-injector.version>
@@ -1785,6 +1786,15 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>java-23-plus-jvm-flags</id>
+      <activation>
+        <jdk>[23,)</jdk>
+      </activation>
+      <properties>
+        <jenkins.java23Plus>--sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED</jenkins.java23Plus>
+      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
## Summary

On Java 24+, XStream's `SunUnsafeReflectionProvider` triggers a terminally deprecated `sun.misc.Unsafe` warning by default ([JEP 498](https://openjdk.org/jeps/498)). JNA similarly warns about restricted native access on Java 23+. Both warnings are harmless — no tests fail — but they produce significant noise in test output (2,000+ warnings per PCT/ATH build run on Java 25).

This adds a Java 23+ Maven profile that injects two JVM flags into Surefire's `argLine` via late-binding `@{jenkins.java23Plus}`:

- `--sun-misc-unsafe-memory-access=allow` — silences XStream `sun.misc.Unsafe` deprecation warning ([x-stream/xstream#362](https://github.com/x-stream/xstream/issues/362))
- `--enable-native-access=ALL-UNNAMED` — silences JNA restricted native-access warning

The flags are gated behind a `[23,)` profile so they are **never** passed to Java 17 or 21, where they would cause an `Unrecognized VM option` error and break the build.
