### PR TITLE
Suppress new `FindImproperSynchronization` SpotBugs detector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,8 +150,18 @@
         THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION
         THROWS_METHOD_THROWS_CLAUSE_THROWABLE
         THROWS_METHOD_THROWS_RUNTIMEEXCEPTION
+      FindImproperSynchronization
+        USO_UNSAFE_METHOD_SYNCHRONIZATION
+        USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION
+        USO_UNSAFE_OBJECT_SYNCHRONIZATION
+        USO_UNSAFE_ACCESSIBLE_OBJECT_SYNCHRONIZATION
+        USO_UNSAFE_INHERITABLE_OBJECT_SYNCHRONIZATION
+        USO_UNSAFE_EXPOSED_OBJECT_SYNCHRONIZATION
+        USBC_UNSAFE_SYNCHRONIZATION_WITH_BACKING_COLLECTION
+        USBC_UNSAFE_SYNCHRONIZATION_WITH_ACCESSIBLE_BACKING_COLLECTION
+        USBC_UNSAFE_SYNCHRONIZATION_WITH_INHERITABLE_BACKING_COLLECTION
     -->
-    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef,MultipleInstantiationsOfSingletons,SharedVariableAtomicityDetector,ThrowingExceptions</spotbugs.omitVisitors>
+    <spotbugs.omitVisitors>ConstructorThrow,FindReturnRef,MultipleInstantiationsOfSingletons,SharedVariableAtomicityDetector,ThrowingExceptions,FindImproperSynchronization</spotbugs.omitVisitors>
 
     <!-- Set to false to enable Spotless -->
     <spotless.check.skip>true</spotless.check.skip>


### PR DESCRIPTION
Suppresses the detector added in https://github.com/spotbugs/spotbugs/pull/3033 which turns up tons of violations in Jenkins plugins that I do not think are worth fixing.

> An attacker can manipulate the system to trigger contention and deadlock by obtaining and indefinitely holding the intrinsic lock of an accessible class, consequently causing a denial of service (DoS).

(If there is an “attacker” who is making Java method calls, it is already game over.)

See https://github.com/jenkinsci/workflow-cps-plugin/pull/1804 or https://github.com/jenkinsci/workflow-job-plugin/pull/777 for example. Seems to have been integrated in https://github.com/jenkinsci/plugin-pom/pull/1402.